### PR TITLE
ReplicaSet and ReplicationController shorthand

### DIFF
--- a/converter/converters/koki_rc_to_kube_v1_rc.go
+++ b/converter/converters/koki_rc_to_kube_v1_rc.go
@@ -1,0 +1,57 @@
+package converters
+
+import (
+	"k8s.io/api/core/v1"
+
+	"github.com/koki/short/types"
+)
+
+func Convert_Koki_ReplicationController_to_Kube_v1_ReplicationController(rc *types.ReplicationControllerWrapper) (*v1.ReplicationController, error) {
+	var err error
+	kubeRC := &v1.ReplicationController{}
+	kokiRC := rc.ReplicationController
+
+	kubeRC.Name = kokiRC.Name
+	kubeRC.Namespace = kokiRC.Namespace
+	kubeRC.APIVersion = kokiRC.Version
+	kubeRC.Kind = "ReplicationController"
+	kubeRC.ClusterName = kokiRC.Cluster
+	kubeRC.Labels = kokiRC.Labels
+	kubeRC.Annotations = kokiRC.Annotations
+
+	kubeRC.Spec.Replicas = kokiRC.Replicas
+	kubeRC.Spec.MinReadySeconds = kokiRC.MinReadySeconds
+	kubeRC.Spec.Selector = kokiRC.PodLabels
+
+	kubeRC.Spec.Template, err = revertTemplate(kokiRC.Template)
+	if err != nil {
+		return nil, err
+	}
+
+	if kokiRC.Status != nil {
+		kubeRC.Status = *kokiRC.Status
+	}
+
+	return kubeRC, nil
+}
+
+func revertTemplate(kokiPod *types.Pod) (*v1.PodTemplateSpec, error) {
+	if kokiPod == nil {
+		return nil, nil
+	}
+
+	kubePod, err := Convert_Koki_Pod_to_Kube_v1_Pod(&types.PodWrapper{Pod: *kokiPod})
+	if err != nil {
+		return nil, err
+	}
+	kubeTemplate := &v1.PodTemplateSpec{
+		Spec: kubePod.Spec,
+	}
+
+	kubeTemplate.Name = kubePod.Name
+	kubeTemplate.Namespace = kubePod.Namespace
+	kubeTemplate.Labels = kubePod.Labels
+	kubeTemplate.Annotations = kubePod.Annotations
+
+	return kubeTemplate, nil
+}

--- a/converter/converters/koki_replicaset_to_kube_v1beta2_replicaset.go
+++ b/converter/converters/koki_replicaset_to_kube_v1beta2_replicaset.go
@@ -1,0 +1,160 @@
+package converters
+
+import (
+	"fmt"
+	"strings"
+
+	apps "k8s.io/api/apps/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/glog"
+	"github.com/koki/short/types"
+	"github.com/koki/short/util"
+)
+
+func Convert_Koki_ReplicaSet_to_Kube_v1_ReplicaSet(rc *types.ReplicaSetWrapper) (*apps.ReplicaSet, error) {
+	var err error
+	kubeRC := &apps.ReplicaSet{}
+	kokiRC := rc.ReplicaSet
+
+	kubeRC.Name = kokiRC.Name
+	kubeRC.Namespace = kokiRC.Namespace
+	kubeRC.APIVersion = kokiRC.Version
+	kubeRC.Kind = "ReplicaSet"
+	kubeRC.ClusterName = kokiRC.Cluster
+	kubeRC.Labels = kokiRC.Labels
+	kubeRC.Annotations = kokiRC.Annotations
+
+	kubeRC.Spec.Replicas = kokiRC.Replicas
+	kubeRC.Spec.MinReadySeconds = kokiRC.MinReadySeconds
+	kubeRC.Spec.Selector, err = parseLabelSelector(kokiRC.PodSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeTemplate, err := revertTemplate(kokiRC.Template)
+	if err != nil {
+		return nil, err
+	}
+
+	if kubeTemplate == nil {
+		return nil, util.TypeValueErrorf(kokiRC, "missing pod template")
+	}
+
+	kubeRC.Spec.Template = *kubeTemplate
+
+	if kokiRC.Status != nil {
+		kubeRC.Status = *kokiRC.Status
+	}
+
+	return kubeRC, nil
+}
+
+func parseLabelSelector(s string) (*metav1.LabelSelector, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	labels := map[string]string{}
+	reqs := []metav1.LabelSelectorRequirement{}
+	segs := strings.Split(s, "&")
+	for _, seg := range segs {
+		expr, err := parseExpr(seg, []string{"!=", "="})
+		if err != nil {
+			return nil, err
+		}
+
+		if expr == nil {
+			if seg[0] == '!' {
+				reqs = append(reqs, metav1.LabelSelectorRequirement{
+					Key:      seg[1:],
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				})
+			} else {
+				reqs = append(reqs, metav1.LabelSelectorRequirement{
+					Key:      seg,
+					Operator: metav1.LabelSelectorOpExists,
+				})
+			}
+
+			continue
+		}
+
+		var op metav1.LabelSelectorOperator
+		switch expr.Op {
+		case "=":
+			op = metav1.LabelSelectorOpIn
+		case "!=":
+			op = metav1.LabelSelectorOpNotIn
+		default:
+			glog.Fatal("unreachable")
+		}
+
+		if len(expr.Values) == 1 {
+			labels[expr.Key] = expr.Values[0]
+		} else {
+			reqs = append(reqs, metav1.LabelSelectorRequirement{
+				Key:      expr.Key,
+				Operator: op,
+				Values:   expr.Values,
+			})
+		}
+	}
+
+	if len(labels) == 0 {
+		labels = nil
+	}
+
+	if len(reqs) == 0 {
+		reqs = nil
+	}
+
+	return &metav1.LabelSelector{
+		MatchLabels:      labels,
+		MatchExpressions: reqs,
+	}, nil
+}
+
+// Expr is the generic AST format of a koki NodeSelectorRequirement or LabelSelectorRequirement
+type Expr struct {
+	Key    string
+	Op     string
+	Values []string
+}
+
+func parseExpr(s string, ops []string) (*Expr, error) {
+	for _, op := range ops {
+		x, err := parseOp(s, op)
+		if err != nil {
+			return nil, err
+		}
+
+		if x != nil {
+			return x, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func parseOp(s string, op string) (*Expr, error) {
+	if strings.Contains(s, op) {
+		segs := strings.Split(s, op)
+		if len(segs) != 2 {
+			return nil, fmt.Errorf(
+				"Unrecognized expression (%s), op (%s)", s, op)
+		}
+
+		return &Expr{
+			Key:    segs[0],
+			Op:     op,
+			Values: parseValues(segs[1]),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func parseValues(s string) []string {
+	return strings.Split(s, ",")
+}

--- a/converter/converters/kube_v1_rc_to_koki_rc.go
+++ b/converter/converters/kube_v1_rc_to_koki_rc.go
@@ -1,0 +1,59 @@
+package converters
+
+import (
+	"reflect"
+
+	"k8s.io/api/core/v1"
+
+	"github.com/koki/short/types"
+)
+
+func Convert_Kube_v1_ReplicationController_to_Koki_ReplicationController(kubeRC *v1.ReplicationController) (*types.ReplicationControllerWrapper, error) {
+	var err error
+	kokiRC := &types.ReplicationController{}
+
+	kokiRC.Name = kubeRC.Name
+	kokiRC.Namespace = kubeRC.Namespace
+	kokiRC.Version = kubeRC.APIVersion
+	kokiRC.Cluster = kubeRC.ClusterName
+	kokiRC.Labels = kubeRC.Labels
+	kokiRC.Annotations = kubeRC.Annotations
+
+	kokiRC.Replicas = kubeRC.Spec.Replicas
+	kokiRC.MinReadySeconds = kubeRC.Spec.MinReadySeconds
+	kokiRC.PodLabels = kubeRC.Spec.Selector
+	kokiRC.Template, err = convertTemplate(kubeRC.Spec.Template)
+	if err != nil {
+		return nil, err
+	}
+
+	if !reflect.DeepEqual(kubeRC.Status, v1.ReplicationControllerStatus{}) {
+		kokiRC.Status = &kubeRC.Status
+	}
+
+	return &types.ReplicationControllerWrapper{
+		ReplicationController: *kokiRC,
+	}, nil
+}
+
+func convertTemplate(kubeTemplate *v1.PodTemplateSpec) (*types.Pod, error) {
+	if kubeTemplate == nil {
+		return nil, nil
+	}
+
+	kubePod := &v1.Pod{
+		Spec: kubeTemplate.Spec,
+	}
+
+	kubePod.Name = kubeTemplate.Name
+	kubePod.Namespace = kubeTemplate.Namespace
+	kubePod.Labels = kubeTemplate.Labels
+	kubePod.Annotations = kubeTemplate.Annotations
+
+	kokiPod, err := Convert_Kube_v1_Pod_to_Koki_Pod(kubePod)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kokiPod.Pod, nil
+}

--- a/converter/converters/kube_v1beta2_replicaset_to_koki_replicaset.go
+++ b/converter/converters/kube_v1beta2_replicaset_to_koki_replicaset.go
@@ -1,0 +1,86 @@
+package converters
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	apps "k8s.io/api/apps/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/koki/short/types"
+)
+
+func Convert_Kube_v1_ReplicaSet_to_Koki_ReplicaSet(kubeRS *apps.ReplicaSet) (*types.ReplicaSetWrapper, error) {
+	var err error
+	kokiRS := &types.ReplicaSet{}
+
+	kokiRS.Name = kubeRS.Name
+	kokiRS.Namespace = kubeRS.Namespace
+	kokiRS.Version = kubeRS.APIVersion
+	kokiRS.Cluster = kubeRS.ClusterName
+	kokiRS.Labels = kubeRS.Labels
+	kokiRS.Annotations = kubeRS.Annotations
+
+	kokiRS.Replicas = kubeRS.Spec.Replicas
+	kokiRS.MinReadySeconds = kubeRS.Spec.MinReadySeconds
+	kokiRS.PodSelector, err = convertLabelSelector(kubeRS.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	kokiRS.Template, err = convertTemplate(&kubeRS.Spec.Template)
+	if err != nil {
+		return nil, err
+	}
+
+	if !reflect.DeepEqual(kubeRS.Status, apps.ReplicaSetStatus{}) {
+		kokiRS.Status = &kubeRS.Status
+	}
+
+	return &types.ReplicaSetWrapper{
+		ReplicaSet: *kokiRS,
+	}, nil
+}
+
+func convertLabelSelector(kubeSelector *metav1.LabelSelector) (string, error) {
+	if kubeSelector == nil {
+		return "", nil
+	}
+
+	affinityString := ""
+	// parse through match labels first
+	for k, v := range kubeSelector.MatchLabels {
+		kokiExpr := fmt.Sprintf("%s=%s", k, v)
+		if len(affinityString) > 0 {
+			affinityString = fmt.Sprintf("%s&%s", affinityString, kokiExpr)
+		} else {
+			affinityString = kokiExpr
+		}
+	}
+
+	// parse through match expressions now
+	for i := range kubeSelector.MatchExpressions {
+		expr := kubeSelector.MatchExpressions[i]
+		value := strings.Join(expr.Values, ",")
+		op, err := convertOperatorLabelSelector(expr.Operator)
+		if err != nil {
+			return "", err
+		}
+		kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
+		if expr.Operator == metav1.LabelSelectorOpExists {
+			kokiExpr = fmt.Sprintf("%s", expr.Key)
+		}
+		if expr.Operator == metav1.LabelSelectorOpDoesNotExist {
+			kokiExpr = fmt.Sprintf("!%s", expr.Key)
+		}
+
+		if len(affinityString) > 0 {
+			affinityString = fmt.Sprintf("%s&%s", affinityString, kokiExpr)
+		} else {
+			affinityString = kokiExpr
+		}
+	}
+
+	return affinityString, nil
+}

--- a/converter/koki_converter.go
+++ b/converter/koki_converter.go
@@ -7,30 +7,35 @@ import (
 	"github.com/koki/short/types"
 	"github.com/koki/short/util"
 
+	apps "k8s.io/api/apps/v1beta2"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func detectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
-	switch kokiObj.(type) {
+	switch kokiObj := kokiObj.(type) {
 	case *types.PodWrapper:
-		return converters.Convert_Koki_Pod_to_Kube_v1_Pod(kokiObj.(*types.PodWrapper))
+		return converters.Convert_Koki_Pod_to_Kube_v1_Pod(kokiObj)
+	case *types.ReplicationControllerWrapper:
+		return converters.Convert_Koki_ReplicationController_to_Kube_v1_ReplicationController(kokiObj)
+	case *types.ReplicaSetWrapper:
+		return converters.Convert_Koki_ReplicaSet_to_Kube_v1_ReplicaSet(kokiObj)
 	default:
 		return nil, util.TypeErrorf(reflect.TypeOf(kokiObj), "Unsupported Type")
 	}
-	return nil, nil
 }
 
 func detectAndConvertFromKubeObj(kubeObj runtime.Object) (interface{}, error) {
-	switch kubeObj.(type) {
+	switch kubeObj := kubeObj.(type) {
 	case *v1.Pod:
-		kokiObj, err := converters.Convert_Kube_v1_Pod_to_Koki_Pod(kubeObj.(*v1.Pod))
-		return kokiObj, err
+		return converters.Convert_Kube_v1_Pod_to_Koki_Pod(kubeObj)
 	case *v1.Service:
-		kokiObj, err := converters.Convert_Kube_v1_Service_to_Koki_Service(kubeObj.(*v1.Service))
-		return kokiObj, err
+		return converters.Convert_Kube_v1_Service_to_Koki_Service(kubeObj)
+	case *v1.ReplicationController:
+		return converters.Convert_Kube_v1_ReplicationController_to_Koki_ReplicationController(kubeObj)
+	case *apps.ReplicaSet:
+		return converters.Convert_Kube_v1_ReplicaSet_to_Koki_ReplicaSet(kubeObj)
 	default:
 		return nil, util.TypeErrorf(reflect.TypeOf(kubeObj), "Unsupported Type")
 	}
-	return nil, nil
 }

--- a/examples/rc/example1.short.yaml
+++ b/examples/rc/example1.short.yaml
@@ -1,0 +1,15 @@
+replicationController:
+  labels:
+    component: example
+  name: example
+  podLabels:
+    key0: value0
+    key1: value1
+  replicas: 1
+  template:
+    containers:
+    - image: gcr.io/kuard-demo/kuard-amd64:1
+      name: kuard
+    labels:
+      component: example
+  version: v1

--- a/examples/rc/example1.yaml
+++ b/examples/rc/example1.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  creationTimestamp: null
+  labels:
+    component: example
+  name: example
+spec:
+  replicas: 1
+  selector:
+    key0: value0
+    key1: value1
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        component: example
+    spec:
+      containers:
+      - image: gcr.io/kuard-demo/kuard-amd64:1
+        name: kuard
+        resources: {}

--- a/examples/rc/f1.short.yaml
+++ b/examples/rc/f1.short.yaml
@@ -1,0 +1,33 @@
+replicationController:
+  labels:
+    component: elasticsearch
+  name: es
+  replicas: 1
+  template:
+    containers:
+    - cap_add:
+      - IPC_LOCK
+      env:
+      - val: KUBERNETES_CA_CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - from: metadata.namespace
+        val: NAMESPACE
+      - val: CLUSTER_NAME=myesdb
+      - val: DISCOVERY_SERVICE=elasticsearch
+      - val: NODE_MASTER=true
+      - val: NODE_DATA=true
+      - val: HTTP_ENABLE=true
+      expose:
+      - name: http
+        port_map: "9200"
+        protocol: TCP
+      - name: transport
+        port_map: "9300"
+        protocol: TCP
+      image: quay.io/pires/docker-elasticsearch-kubernetes:1.7.1-4
+      name: es
+      volume:
+      - mount: /data
+        store: storage
+    labels:
+      component: elasticsearch
+  version: v1

--- a/examples/replicaset/example1.short.yaml
+++ b/examples/replicaset/example1.short.yaml
@@ -1,0 +1,17 @@
+replicaSet:
+  labels:
+    component: example
+  name: example
+  podSelector: key0=value0&key1=value1,value2&!key2&key3!=value3,value4
+  replicas: 1
+  template:
+    containers:
+    - image: gcr.io/kuard-demo/kuard-amd64:1
+      imagePullPolicy: IfNotPresent
+      name: kuard
+      resources: {}
+    dnsPolicy: ClusterFirst
+    restartPolicy: Never
+    labels:
+      component: example
+  version: apps/v1beta2

--- a/examples/replicaset/example1.yaml
+++ b/examples/replicaset/example1.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  creationTimestamp: null
+  labels:
+    component: example
+  name: example
+spec:
+  replicas: 1
+  selector:
+    matchExpressions:
+    - key: key1
+      operator: In
+      values:
+      - value1
+      - value2
+    - key: key2
+      operator: DoesNotExist
+    - key: key3
+      operator: NotIn
+      values:
+      - value3
+      - value4
+    matchLabels:
+      key0: value0
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        component: example
+    spec:
+      containers:
+      - image: gcr.io/kuard-demo/kuard-amd64:1
+        name: kuard
+        resources: {}

--- a/examples/replicaset/f1.short.yaml
+++ b/examples/replicaset/f1.short.yaml
@@ -1,0 +1,33 @@
+replicaSet:
+  labels:
+    component: elasticsearch
+  name: es
+  replicas: 1
+  template:
+    containers:
+    - cap_add:
+      - IPC_LOCK
+      env:
+      - val: KUBERNETES_CA_CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      - from: metadata.namespace
+        val: NAMESPACE
+      - val: CLUSTER_NAME=myesdb
+      - val: DISCOVERY_SERVICE=elasticsearch
+      - val: NODE_MASTER=true
+      - val: NODE_DATA=true
+      - val: HTTP_ENABLE=true
+      expose:
+      - name: http
+        port_map: "9200"
+        protocol: TCP
+      - name: transport
+        port_map: "9300"
+        protocol: TCP
+      image: quay.io/pires/docker-elasticsearch-kubernetes:1.7.1-4
+      name: es
+      volume:
+      - mount: /data
+        store: storage
+    labels:
+      component: elasticsearch
+  version: apps/v1beta2

--- a/examples/replicaset/f1.yaml
+++ b/examples/replicaset/f1.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1beta2
+kind: ReplicaSet
 metadata:
   name: es
   labels:

--- a/parser/native.go
+++ b/parser/native.go
@@ -30,6 +30,19 @@ func ParseKokiNativeObject(obj interface{}) (interface{}, error) {
 			err := json.Unmarshal(bytes, pod)
 			return pod, err
 		}
+
+		if k == "replicaSet" {
+			replicaSet := &types.ReplicaSetWrapper{}
+			err := json.Unmarshal(bytes, replicaSet)
+			return replicaSet, err
+		}
+
+		if k == "replicationController" {
+			replicationController := &types.ReplicationControllerWrapper{}
+			err := json.Unmarshal(bytes, replicationController)
+			return replicationController, err
+		}
+
 		return nil, util.TypeValueErrorf(objMap, "Unexpected value %s", k)
 	}
 

--- a/types/replicaset.go
+++ b/types/replicaset.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	apps "k8s.io/api/apps/v1beta2"
+)
+
+type ReplicaSetWrapper struct {
+	ReplicaSet ReplicaSet `json:"replicaSet"`
+}
+
+type ReplicaSet struct {
+	Version     string            `json:"version,omitempty"`
+	Cluster     string            `json:"cluster,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	Replicas        *int32 `json:"replicas,omitempty"`
+	MinReadySeconds int32  `json:"minReadySeconds,omitempty"`
+	PodSelector     string `json:"podSelector,omitempty"`
+	Template        *Pod   `json:"template,omitempty"`
+
+	Status *apps.ReplicaSetStatus `json:"status,omitempty"`
+}

--- a/types/replicationcontroller.go
+++ b/types/replicationcontroller.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+type ReplicationControllerWrapper struct {
+	ReplicationController ReplicationController `json:"replicationController"`
+}
+
+type ReplicationController struct {
+	Version     string            `json:"version,omitempty"`
+	Cluster     string            `json:"cluster,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	Replicas        *int32            `json:"replicas,omitempty"`
+	MinReadySeconds int32             `json:"minReadySeconds,omitempty"`
+	PodLabels       map[string]string `json:"podLabels,omitempty"`
+	Template        *Pod              `json:"template,omitempty"`
+
+	Status *v1.ReplicationControllerStatus `json:"status,omitempty"`
+}


### PR DESCRIPTION
The interesting pieces of ReplicaSet and ReplicationController shorthand:

ReplicaSet.Selector is a LabelSelector like PodAffinity. I copied some code from #29, so there will be some conflict resolution once #29 is merged.

ReplicaSet.Spec.Template and ReplicationController.Spec.Template are converted to/from koki Pod syntax using the existing conversions between kube Pod and koki Pod.

RS/RC.Status is untouched (no-op conversion) for now.

@wlan0