### PR TITLE
expose k8s-object parsing for clients of short (as a lib)

### DIFF
--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -114,7 +114,7 @@ func short(c *cobra.Command, args []string) error {
 		return err
 	}
 
-	var convertedData interface{}
+	var convertedData []interface{}
 
 	if kubeNative {
 		glog.V(3).Info("converting input to kubernetes native syntax")

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -1,19 +1,14 @@
 package converter
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	unstructuredconversion "k8s.io/apimachinery/pkg/conversion/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/koki/short/parser"
 )
 
-func ConvertToKubeNative(in interface{}) (interface{}, error) {
-	objs, ok := in.([]map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("Error casting input object to type map[string]interface{}")
-	}
+func ConvertToKubeNative(objs []map[string]interface{}) ([]interface{}, error) {
 	convertedTypes := []interface{}{}
 	for i := range objs {
 		obj := objs[i]
@@ -32,25 +27,29 @@ func ConvertToKubeNative(in interface{}) (interface{}, error) {
 	return convertedTypes, nil
 }
 
-func ConvertToKokiNative(in interface{}) (interface{}, error) {
-	objs, ok := in.([]map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("Error casting input object to type map[string]interface{}")
+func ParseSingleKubeNative(obj map[string]interface{}) (runtime.Object, error) {
+	u := &unstructured.Unstructured{
+		Object: obj,
 	}
 
+	typedObj, err := creator.New(u.GetObjectKind().GroupVersionKind())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := unstructuredconversion.DefaultConverter.FromUnstructured(obj, typedObj); err != nil {
+		return nil, err
+	}
+
+	return typedObj, err
+}
+
+func ConvertToKokiNative(objs []map[string]interface{}) ([]interface{}, error) {
 	convertedTypes := []interface{}{}
 	for i := range objs {
 		obj := objs[i]
-		u := &unstructured.Unstructured{
-			Object: obj,
-		}
-
-		typedObj, err := creator.New(u.GetObjectKind().GroupVersionKind())
+		typedObj, err := ParseSingleKubeNative(obj)
 		if err != nil {
-			return nil, err
-		}
-
-		if err := unstructuredconversion.DefaultConverter.FromUnstructured(obj, typedObj); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
this will make it easier for the koki cli (and other future clients?) to use `short` as a do-all frontend for reading both kube and koki manifeset files.

specific use case is creating resources from both kinds of manifest files from the koki cli.

I also made the type signatures of those parse/convert methods more explicit.

@wlan0