### PR TITLE
import syntax support

### DIFF
--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -19,8 +19,8 @@ var (
 	RootCmd = &cobra.Command{
 		Use:   "short",
 		Short: "Manageable Kubernetes manifests using koki/short",
-		Long: `Short converts the api-friendly kubernetes manifests into ops-friendly syntax. 
-		
+		Long: `Short converts the api-friendly kubernetes manifests into ops-friendly syntax.
+
 Full documentation available at https://docs.koki.io/short
 `,
 		RunE:         short,
@@ -43,8 +43,8 @@ Full documentation available at https://docs.koki.io/short
   short --kube-native -f pod_short.yaml
   short -k -f pod_short.yaml
 
-  # Output to file 
-  short -f pod.yaml -o pod_short.yaml	
+  # Output to file
+  short -f pod.yaml -o pod_short.yaml
 `,
 	}
 
@@ -106,6 +106,8 @@ func short(c *cobra.Command, args []string) error {
 		glog.V(3).Info("using stdin for input data")
 		useStdin = true
 	}
+
+	return doFilesWithImports(filenames)
 
 	// parse input data from one of the sources - files or stdin
 	glog.V(3).Info("parsing input data")

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -79,6 +79,7 @@ func init() {
 }
 
 func short(c *cobra.Command, args []string) error {
+	var err error
 	// validate that the user used the command correctly
 	glog.V(3).Infof("validating command %q", args)
 
@@ -107,29 +108,41 @@ func short(c *cobra.Command, args []string) error {
 		useStdin = true
 	}
 
-	return doFilesWithImports(filenames)
-
-	// parse input data from one of the sources - files or stdin
-	glog.V(3).Info("parsing input data")
-	data, err := parser.Parse(filenames, useStdin)
-	if err != nil {
-		return err
-	}
-
 	var convertedData interface{}
 
-	if kubeNative {
-		glog.V(3).Info("converting input to kubernetes native syntax")
-		convertedData, err = converter.ConvertToKubeNative(data)
+	if !useStdin && kubeNative {
+		// Imports are only supported for normal files in koki syntax.
+		kokiObjs, err := loadKokiFiles(filenames)
+		if err != nil {
+			return err
+		}
+
+		convertedData, err = convertKokiObjs(kokiObjs)
 		if err != nil {
 			return err
 		}
 	} else {
-		glog.V(3).Info("converting input to koki native syntax")
-		convertedData, err = converter.ConvertToKokiNative(data)
+		// parse input data from one of the sources - files or stdin
+		glog.V(3).Info("parsing input data")
+		data, err := parser.Parse(filenames, useStdin)
 		if err != nil {
 			return err
 		}
+
+		if kubeNative {
+			glog.V(3).Info("converting input to kubernetes native syntax")
+			convertedData, err = converter.ConvertToKubeNative(data)
+			if err != nil {
+				return err
+			}
+		} else {
+			glog.V(3).Info("converting input to koki native syntax")
+			convertedData, err = converter.ConvertToKokiNative(data)
+			if err != nil {
+				return err
+			}
+		}
+
 	}
 
 	if silent {

--- a/cmd/short.go
+++ b/cmd/short.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/kr/pretty"
+
+	"github.com/koki/short/imports"
+	"github.com/koki/short/param"
+	"github.com/koki/short/parser"
+)
+
+func doFilesWithImports(filenames []string) error {
+	for _, filename := range filenames {
+		module, err := imports.Parse(filename)
+		if err != nil {
+			return err
+		}
+
+		evalContext := imports.EvalContext{
+			RawToTyped:  parser.ParseKokiNativeObject,
+			ApplyParams: param.ApplyParams,
+		}
+
+		err = evalContext.EvaluateModule(module)
+		if err != nil {
+			return err
+		}
+
+		bytes, err := yaml.Marshal(module.TypedResult)
+		if err != nil {
+			return err
+		}
+		pretty.Println(string(bytes))
+	}
+
+	return nil
+}

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -23,7 +23,7 @@ func ConvertToKubeNative(in interface{}) (interface{}, error) {
 			return nil, nil
 		}
 
-		kubeObj, err := detectAndConvertFromKokiObj(typedObj)
+		kubeObj, err := DetectAndConvertFromKokiObj(typedObj)
 		if err != nil {
 			return nil, err
 		}
@@ -54,7 +54,7 @@ func ConvertToKokiNative(in interface{}) (interface{}, error) {
 			return nil, err
 		}
 
-		kokiObj, err := detectAndConvertFromKubeObj(typedObj)
+		kokiObj, err := DetectAndConvertFromKubeObj(typedObj)
 		if err != nil {
 			return nil, err
 		}

--- a/converter/converters/koki_pod_to_kube_v1_pod.go
+++ b/converter/converters/koki_pod_to_kube_v1_pod.go
@@ -28,6 +28,7 @@ func Convert_Koki_Pod_to_Kube_v1_Pod(pod *types.PodWrapper) (*v1.Pod, error) {
 
 	kubePod.Spec = v1.PodSpec{}
 
+	kubePod.Spec.Volumes = kokiPod.Volumes
 	fields := strings.SplitN(kokiPod.Hostname, ".", 2)
 	if len(fields) == 1 {
 		kubePod.Spec.Hostname = kokiPod.Hostname

--- a/converter/converters/kube_v1_pod_to_koki.go
+++ b/converter/converters/kube_v1_pod_to_koki.go
@@ -22,6 +22,7 @@ func Convert_Kube_v1_Pod_to_Koki_Pod(pod *v1.Pod) (*types.PodWrapper, error) {
 	kokiPod.Labels = pod.Labels
 	kokiPod.Annotations = pod.Annotations
 
+	kokiPod.Volumes = pod.Spec.Volumes
 	affinity, err := convertAffinity(pod.Spec)
 	if err != nil {
 		return nil, err

--- a/converter/koki_converter.go
+++ b/converter/koki_converter.go
@@ -26,6 +26,8 @@ func DetectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
 		return converters.Convert_Koki_ReplicaSet_to_Kube_v1beta2_ReplicaSet(kokiObj)
 	case *types.ServiceWrapper:
 		return converters.Convert_Koki_Service_To_Kube_v1_Service(kokiObj)
+	case *types.VolumeWrapper:
+		return &kokiObj.Volume, nil
 	default:
 		return nil, util.TypeErrorf(reflect.TypeOf(kokiObj), "Unsupported Type")
 	}

--- a/converter/koki_converter.go
+++ b/converter/koki_converter.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func detectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
+func DetectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
 	switch kokiObj := kokiObj.(type) {
 	case *types.DeploymentWrapper:
 		return converters.Convert_Koki_Deployment_to_Kube_v1beta1_Deployment(kokiObj)
@@ -31,7 +31,7 @@ func detectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
 	}
 }
 
-func detectAndConvertFromKubeObj(kubeObj runtime.Object) (interface{}, error) {
+func DetectAndConvertFromKubeObj(kubeObj runtime.Object) (interface{}, error) {
 	switch kubeObj := kubeObj.(type) {
 	case *exts.Deployment:
 		return converters.Convert_Kube_v1beta2_Deployment_to_Koki_Deployment(kubeObj)

--- a/examples/imports/deployment0.yaml
+++ b/examples/imports/deployment0.yaml
@@ -1,7 +1,12 @@
 imports:
+- otherVol: volume0.yaml
 - deployment: ../deployment/example1.short.yaml
   params:
     pod: ${pod}
 - pod: ../pods/example2.short.yaml
+  params:
+    name: podName0
+    containers.nginx.volumeMounts: ${otherVol}
+    
 ---
 ${deployment}

--- a/examples/imports/deployment0.yaml
+++ b/examples/imports/deployment0.yaml
@@ -1,0 +1,7 @@
+imports:
+- deployment: ../deployment/example1.short.yaml
+  params:
+    pod: ${pod}
+- pod: ../pods/example2.short.yaml
+---
+${deployment}

--- a/examples/imports/generic-service0.yaml
+++ b/examples/imports/generic-service0.yaml
@@ -1,0 +1,8 @@
+service:
+  clientIPAffinitySeconds: Default
+  clusterIP: 1.1.1.10
+  externalIPs:
+  - 1.1.1.1
+  name: example
+  port: 80:8080
+  version: v1

--- a/examples/imports/pod0.yaml
+++ b/examples/imports/pod0.yaml
@@ -1,0 +1,9 @@
+imports:
+- data_vol: ../pv/example1.short.yaml
+- pod: ../pods/example2.short.yaml
+  params:
+    name: name1
+    containers.nginx.volume_mounts: 
+      ${data_vol}
+---
+${pod}

--- a/examples/imports/pod0.yaml
+++ b/examples/imports/pod0.yaml
@@ -1,9 +1,11 @@
 imports:
-- data_vol: ../pv/example1.short.yaml
+- dataVol: ../pv/example1.short.yaml
+- otherVol: volume0.yaml
 - pod: ../pods/example2.short.yaml
   params:
     name: name1
-    containers.nginx.volume_mounts: 
-      ${data_vol}
+    containers.nginx.volumeMounts: 
+    - ${dataVol}
+    - ${otherVol}
 ---
 ${pod}

--- a/examples/imports/rc0.yaml
+++ b/examples/imports/rc0.yaml
@@ -1,0 +1,7 @@
+imports:
+- pod: ../pods/example2.short.yaml
+- replicationcontroller: ../rc/example1.short.yaml
+  params:
+    pod: ${pod}
+---
+${replicationcontroller}

--- a/examples/imports/replicaset0.yaml
+++ b/examples/imports/replicaset0.yaml
@@ -1,0 +1,7 @@
+imports:
+- pod: ../pods/example2.short.yaml
+- replicaset: ../replicaset/example1.short.yaml
+  params:
+    pod: ${pod}
+---
+${replicaset}

--- a/examples/imports/service0.yaml
+++ b/examples/imports/service0.yaml
@@ -1,0 +1,7 @@
+imports:
+- pod: ../pods/example2.short.yaml
+- service: ../service/example2.short.yaml
+  params:
+    pod: ${pod}
+---
+${service}

--- a/examples/imports/volume0.yaml
+++ b/examples/imports/volume0.yaml
@@ -1,0 +1,3 @@
+volume:
+  name: emptydir
+  emptyDir: {}

--- a/imports/eval.go
+++ b/imports/eval.go
@@ -1,0 +1,92 @@
+package imports
+
+import (
+	"fmt"
+
+	"github.com/koki/short/util"
+)
+
+/*
+
+How evaluation works:
+
+Every module starts out Raw and unevaluated.
+
+An import is evaluated by:
+  1. Evaluate its Module.
+  2. Apply its Params to its Module using the other Imports.
+
+A module is evaluated by:
+  1. Build its Result by filling its Raw template from the Module.Raw of its Imports.
+  2. Parse its TypedResult
+
+*/
+
+func (c *EvalContext) EvaluateImport(inModule *Module, imprt *Import) error {
+	if imprt.IsEvaluated {
+		return nil
+	}
+
+	// Evaluate the Module.
+	err := c.EvaluateModule(imprt.Module)
+	if err != nil {
+		return err
+	}
+
+	params, err := FillTemplate(imprt.Params, c.ResolverForModule(inModule))
+	if err != nil {
+		return err
+	}
+	if paramsMap, ok := params.(map[string]interface{}); ok {
+		imprt.Params = paramsMap
+	} else {
+		return util.PrettyTypeError(params, "filling a dictionary template resulted in non-dictionary result")
+	}
+
+	err = c.ApplyParams(imprt.Params, imprt.Module)
+	if err != nil {
+		return err
+	}
+
+	imprt.IsEvaluated = true
+	return nil
+}
+
+func (c *EvalContext) EvaluateModule(module *Module) error {
+	if module.IsEvaluated {
+		return nil
+	}
+
+	var err error
+
+	module.Raw, err = FillTemplate(module.Raw, c.ResolverForModule(module))
+	if err != nil {
+		return err
+	}
+
+	module.TypedResult, err = c.RawToTyped(module.Raw)
+	if err != nil {
+		module.TypedResult = err
+	}
+
+	module.IsEvaluated = true
+	return nil
+}
+
+func (c *EvalContext) ResolverForModule(module *Module) Resolver {
+	return Resolver(func(ident string) (interface{}, error) {
+		for _, imprt := range module.Imports {
+			if imprt.Name == ident {
+				// Make sure the Import has been evaluated.
+				err := c.EvaluateImport(module, imprt)
+				if err != nil {
+					return nil, err
+				}
+
+				return imprt.Module.Raw, nil
+			}
+		}
+
+		return nil, fmt.Errorf("no value for (%s) in file (%s)", ident, module.Path)
+	})
+}

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -1,0 +1,101 @@
+package imports
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/koki/short/util"
+)
+
+func Parse(rootPath string) (*Module, error) {
+	components, err := ReadYamls(rootPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(components) > 2 {
+		return nil, fmt.Errorf("file (%s) should have at most one imports section and one manifest section", rootPath)
+	}
+
+	if len(components) == 1 {
+		return &Module{
+			Path: rootPath,
+			Raw:  components[0],
+		}, nil
+	}
+
+	imports := []*Import{}
+	if imprtsDoc, ok := components[0].(map[string]interface{}); ok {
+		if imprts, ok := imprtsDoc["imports"]; ok {
+			if imprts, ok := imprts.([]interface{}); ok {
+				for _, imprt := range imprts {
+					if imprt, ok := imprt.(map[string]interface{}); ok {
+						anImport, err := parseImport(rootPath, imprt)
+						if err != nil {
+							return nil, err
+						}
+						imports = append(imports, anImport)
+					} else {
+						return nil, util.PrettyTypeError(imprt, "expected an import declaration in "+rootPath)
+					}
+				}
+			} else {
+				return nil, util.PrettyTypeError(imprts, "expected array of imports in "+rootPath)
+			}
+		} else {
+			return nil, fmt.Errorf("file (%s) should have 'imports' as its first section", rootPath)
+		}
+	} else {
+		return nil, util.PrettyTypeError(components[0], "imports section should be a map in "+rootPath)
+	}
+
+	return &Module{
+		Path:    rootPath,
+		Imports: imports,
+		Raw:     components[1],
+	}, nil
+}
+
+func parseImport(rootPath string, imprt map[string]interface{}) (*Import, error) {
+	var err error
+	if len(imprt) == 0 {
+		return nil, util.PrettyTypeError(imprt, "empty import declaration")
+	}
+	if len(imprt) > 2 {
+		return nil, util.PrettyTypeError(imprt, "import declaration should have at most params and name:path")
+	}
+
+	imp := &Import{}
+	for key, val := range imprt {
+		if key == "params" {
+			if params, ok := val.(map[string]interface{}); ok {
+				imp.Params = params
+			} else {
+				return nil, util.PrettyTypeError(imprt, "params should be a dictionary")
+			}
+		} else {
+			imp.Name = key
+			if importPath, ok := val.(string); ok {
+				imp.Path = convertImportPath(rootPath, importPath)
+			} else {
+				return nil, util.PrettyTypeError(imprt, "import path should be a string")
+			}
+		}
+	}
+
+	if len(imp.Name) == 0 {
+		return nil, util.PrettyTypeError(imprt, "expected import name and path")
+	}
+
+	imp.Module, err = Parse(imp.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	return imp, nil
+}
+
+func convertImportPath(rootPath string, relativePath string) string {
+	dirPath, _ := filepath.Split(rootPath)
+	return filepath.Join(dirPath, relativePath)
+}

--- a/imports/template.go
+++ b/imports/template.go
@@ -1,0 +1,128 @@
+package imports
+
+import (
+	"regexp"
+
+	"github.com/kr/pretty"
+
+	"github.com/koki/short/util"
+)
+
+/*
+
+Template "holes" are represented as the string "${NAME}".
+
+If a "hole" is part of (but not all of) a string, then only string/number values are supported.
+This behavior is defined in `generic.fillString`.
+
+Parameter values may also have document structure and will retain
+this structure when inserted into the template.
+
+*/
+
+// Resolver gets the value to substitute into the template.
+type Resolver func(ident string) (interface{}, error)
+
+func FillTemplate(template interface{}, resolver Resolver) (interface{}, error) {
+	return replaceAny(template, resolver)
+}
+
+func replaceAny(template interface{}, resolver Resolver) (interface{}, error) {
+	switch template := template.(type) {
+	case string:
+		return replaceString(template, resolver)
+	case []interface{}:
+		return replaceSlice(template, resolver)
+	case map[string]interface{}:
+		return replaceMap(template, resolver)
+	default:
+		// No template parameters in other data types.
+	}
+
+	return template, nil
+}
+
+func replaceMap(template map[string]interface{}, resolver Resolver) (map[string]interface{}, error) {
+	var err error
+	for key, val := range template {
+		template[key], err = replaceAny(val, resolver)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return template, nil
+}
+
+func replaceSlice(template []interface{}, resolver Resolver) ([]interface{}, error) {
+	var err error
+	for ix, val := range template {
+		template[ix], err = replaceAny(val, resolver)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return template, nil
+}
+
+func replaceString(template string, resolver Resolver) (interface{}, error) {
+	// Find all template holes and replace them with param values.
+	expanded, modified, err := expandString(template, resolver)
+	if err != nil {
+		return nil, err
+	}
+
+	if modified {
+		return expanded, nil
+	}
+
+	return fillString(template, resolver)
+}
+
+// Returns true if it expanded the template.
+func expandString(template string, resolver Resolver) (interface{}, bool, error) {
+	re := regexp.MustCompile("^\\$\\{([^\\{\\}]*)\\}$")
+	matches := re.FindStringSubmatch(template)
+	if len(matches) == 0 {
+		return template, false, nil
+	}
+
+	key := matches[1]
+	val, err := resolver(key)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return val, true, nil
+}
+
+func fillString(template string, resolver Resolver) (string, error) {
+	re := regexp.MustCompile("\\$\\{[^\\{\\}]*\\}")
+	errors := []error{}
+	result := re.ReplaceAllFunc([]byte(template), func(match []byte) []byte {
+		key := match[2 : len(match)-1]
+		val, err := resolver(string(key))
+		if err != nil {
+			errors = append(errors, err)
+		}
+
+		switch val := val.(type) {
+		case string:
+			return []byte(val)
+		case float64:
+			return []byte(pretty.Sprintf("%v", val))
+		case int:
+			return []byte(pretty.Sprintf("%v", val))
+		default:
+			errors = append(errors, util.PrettyTypeError(val, "not a string or number"))
+			return match
+		}
+	})
+
+	if len(errors) > 0 {
+		return "", errors[0]
+	}
+
+	return string(result), nil
+}

--- a/imports/types.go
+++ b/imports/types.go
@@ -1,0 +1,31 @@
+package imports
+
+type Import struct {
+	Name   string
+	Path   string
+	Params map[string]interface{}
+
+	// IsEvaluated have the Params been applied to the Module?
+	IsEvaluated bool
+
+	Module *Module
+}
+
+type Module struct {
+	Path    string
+	Imports []*Import
+
+	// Raw yaml parsed as string or map[string]interface{}
+	Raw interface{}
+
+	// IsEvaluated has the Raw yaml been evaluated (template holes filled, etc)?
+	IsEvaluated bool
+
+	// TypedResult a koki object (or other object with special meaning)
+	TypedResult interface{}
+}
+
+type EvalContext struct {
+	RawToTyped  func(raw interface{}) (interface{}, error)
+	ApplyParams func(params map[string]interface{}, module *Module) error
+}

--- a/imports/yamls.go
+++ b/imports/yamls.go
@@ -1,0 +1,44 @@
+package imports
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+)
+
+// ReadYamls read a yaml file of potentially multiple documents.
+func ReadYamls(filename string) ([]interface{}, error) {
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	yamls := SplitYaml(contents)
+	objs := make([]interface{}, len(yamls))
+	for ix, y := range yamls {
+		obj := map[string]interface{}{}
+		mapErr := yaml.Unmarshal(y, &obj)
+		if mapErr == nil {
+			objs[ix] = obj
+			continue
+		}
+
+		str := ""
+		strErr := yaml.Unmarshal(y, &str)
+		if strErr == nil {
+			objs[ix] = str
+			continue
+		}
+
+		return nil, fmt.Errorf("(%s)\n(%s)", mapErr.Error(), strErr.Error())
+	}
+
+	return objs, nil
+}
+
+// SplitYaml split multi-document yaml file.
+func SplitYaml(contents []byte) [][]byte {
+	return bytes.Split(contents, []byte("\n---\n"))
+}

--- a/param/apply.go
+++ b/param/apply.go
@@ -1,0 +1,39 @@
+package param
+
+import (
+	"github.com/koki/short/imports"
+	"github.com/koki/short/parser"
+	"github.com/koki/short/types"
+	"github.com/koki/short/util"
+)
+
+func ApplyParams(params map[string]interface{}, module *imports.Module) error {
+	if len(params) == 0 {
+		return nil
+	}
+
+	var err error
+	switch obj := module.TypedResult.(type) {
+	case *types.PodWrapper:
+		err = ApplyPodParams(params, obj)
+	case *types.ServiceWrapper:
+		err = ApplyServiceParams(params, obj)
+	case *types.ReplicaSetWrapper:
+		err = ApplyReplicaSetParams(params, obj)
+	case *types.ReplicationControllerWrapper:
+		err = ApplyReplicationControllerParams(params, obj)
+	case *types.DeploymentWrapper:
+		err = ApplyDeploymentParams(params, obj)
+	default:
+		err = util.TypeValueErrorf(obj, "unsupported type for parameterization")
+	}
+
+	if err != nil {
+		return nil
+	}
+
+	// Update Raw to reflect new TypedResult.
+	module.Raw, err = parser.UnparseKokiNativeObject(module.TypedResult)
+
+	return err
+}

--- a/param/apply_deployment.go
+++ b/param/apply_deployment.go
@@ -1,0 +1,39 @@
+package param
+
+import (
+	"github.com/koki/short/parser"
+	"github.com/koki/short/types"
+	"github.com/koki/short/util"
+)
+
+func ApplyDeploymentParams(params map[string]interface{}, wrapper *types.DeploymentWrapper) error {
+	deployment := &wrapper.Deployment
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			deployment.Name = name
+			if deployment.Labels != nil {
+				deployment.Labels["name"] = name
+			} else {
+				deployment.Labels = map[string]string{
+					"name": name,
+				}
+			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
+		}
+	}
+
+	if pod, ok := params["pod"]; ok {
+		kokiObj, err := parser.ParseKokiNativeObject(pod)
+		if err != nil {
+			return err
+		}
+		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+			deployment.Template = kokiPod.Pod
+		} else {
+			return util.PrettyTypeError(kokiObj, "expected a pod")
+		}
+	}
+
+	return nil
+}

--- a/param/apply_pod.go
+++ b/param/apply_pod.go
@@ -1,0 +1,114 @@
+package param
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/koki/short/parser"
+	"github.com/koki/short/types"
+	"github.com/koki/short/util"
+)
+
+func ApplyPodParams(params map[string]interface{}, wrapper *types.PodWrapper) error {
+	pod := &wrapper.Pod
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			pod.Name = name
+			if pod.Labels != nil {
+				pod.Labels["name"] = name
+			} else {
+				pod.Labels = map[string]string{
+					"name": name,
+				}
+			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
+		}
+	}
+
+	err := applyVolumeMountParams(params, pod)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type volumeMountParam struct {
+	ContainerName string
+	Volumes       []interface{}
+}
+
+// containers.${CONTAINER_NAME}.volume_mounts:
+func parseVolumeMountParam(key string, value interface{}) (*volumeMountParam, error) {
+	re := regexp.MustCompile(`^containers\.([^\.]*)\.volume_mounts$`)
+
+	matches := re.FindStringSubmatch(key)
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("(%s) isn't a volume mount param", key)
+	}
+
+	vmParam := &volumeMountParam{
+		ContainerName: matches[1],
+	}
+
+	var volumes []interface{}
+	if values, ok := value.([]interface{}); ok {
+		// value is multiple volumes
+		volumes = values
+	} else {
+		// value is just one volume
+		volumes = []interface{}{value}
+	}
+
+	vmParam.Volumes = make([]interface{}, len(volumes))
+	for i, volume := range volumes {
+		kokiVolume, err := parser.ParseKokiNativeObject(volume)
+		if err != nil {
+			return nil, err
+		}
+		vmParam.Volumes[i] = kokiVolume
+	}
+
+	return vmParam, nil
+}
+
+func applyVolumeMountParams(params map[string]interface{}, pod *types.Pod) error {
+	for param, value := range params {
+		vmParam, err := parseVolumeMountParam(param, value)
+		if err != nil {
+			continue
+		}
+
+		for _, volume := range vmParam.Volumes {
+			// TODO: non-persistent volumes
+			switch volume := volume.(type) {
+			case *types.PersistentVolumeWrapper:
+				err := applyPersistentVolumeMount(vmParam, volume, pod)
+				if err != nil {
+					return err
+				}
+			default:
+				return util.PrettyTypeError(volume, "unsupported type for volume mount")
+			}
+		}
+	}
+
+	return nil
+}
+
+func applyPersistentVolumeMount(vmParam *volumeMountParam, volume *types.PersistentVolumeWrapper, pod *types.Pod) error {
+	for i, container := range pod.Containers {
+		if container.Name == vmParam.ContainerName {
+			volumeName := volume.PersistentVolume.Name
+			volumeMount := &types.VolumeMount{
+				MountPath: "/" + volumeName,
+				Store:     volumeName,
+			}
+			container.VolumeMounts = append(container.VolumeMounts, *volumeMount)
+			pod.Containers[i] = container
+		}
+	}
+
+	return nil
+}

--- a/param/apply_replicaset.go
+++ b/param/apply_replicaset.go
@@ -1,0 +1,41 @@
+package param
+
+import (
+	"github.com/koki/short/parser"
+	"github.com/koki/short/types"
+	"github.com/koki/short/util"
+)
+
+func ApplyReplicaSetParams(params map[string]interface{}, wrapper *types.ReplicaSetWrapper) error {
+	replicaSet := &wrapper.ReplicaSet
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			replicaSet.Name = name
+			if replicaSet.Labels != nil {
+				replicaSet.Labels["name"] = name
+			} else {
+				replicaSet.Labels = map[string]string{
+					"name": name,
+				}
+			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
+		}
+	}
+
+	if pod, ok := params["pod"]; ok {
+		kokiObj, err := parser.ParseKokiNativeObject(pod)
+		if err != nil {
+			return err
+		}
+		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+			replicaSet.Template = &kokiPod.Pod
+			// Empty selector just uses template's labels.
+			replicaSet.PodSelector = ""
+		} else {
+			return util.PrettyTypeError(kokiObj, "expected a pod")
+		}
+	}
+
+	return nil
+}

--- a/param/apply_replicationcontroller.go
+++ b/param/apply_replicationcontroller.go
@@ -1,0 +1,41 @@
+package param
+
+import (
+	"github.com/koki/short/parser"
+	"github.com/koki/short/types"
+	"github.com/koki/short/util"
+)
+
+func ApplyReplicationControllerParams(params map[string]interface{}, wrapper *types.ReplicationControllerWrapper) error {
+	rc := &wrapper.ReplicationController
+
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			rc.Name = name
+			if rc.Labels != nil {
+				rc.Labels["name"] = name
+			} else {
+				rc.Labels = map[string]string{
+					"name": name,
+				}
+			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
+		}
+	}
+
+	if pod, ok := params["pod"]; ok {
+		kokiObj, err := parser.ParseKokiNativeObject(pod)
+		if err != nil {
+			return err
+		}
+		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+			rc.Template = &kokiPod.Pod
+			// Empty selector just uses template's labels.
+			rc.PodLabels = nil
+		} else {
+			return util.PrettyTypeError(kokiObj, "expected a pod")
+		}
+	}
+	return nil
+}

--- a/param/apply_service.go
+++ b/param/apply_service.go
@@ -1,0 +1,40 @@
+package param
+
+import (
+	"github.com/koki/short/parser"
+	"github.com/koki/short/types"
+	"github.com/koki/short/util"
+)
+
+func ApplyServiceParams(params map[string]interface{}, wrapper *types.ServiceWrapper) error {
+	service := &wrapper.Service
+
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			service.Name = name
+			if service.Labels != nil {
+				service.Labels["name"] = name
+			} else {
+				service.Labels = map[string]string{
+					"name": name,
+				}
+			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
+		}
+	}
+
+	if pod, ok := params["pod"]; ok {
+		kokiObj, err := parser.ParseKokiNativeObject(pod)
+		if err != nil {
+			return err
+		}
+		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+			service.PodLabels = kokiPod.Pod.Labels
+		} else {
+			return util.PrettyTypeError(kokiObj, "expected a pod")
+		}
+	}
+
+	return nil
+}

--- a/parser/native.go
+++ b/parser/native.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/koki/short/types"
 	"github.com/koki/short/util"
+
+	"github.com/ghodss/yaml"
 )
 
 func ParseKokiNativeObject(obj interface{}) (interface{}, error) {
@@ -56,4 +58,20 @@ func ParseKokiNativeObject(obj interface{}) (interface{}, error) {
 	}
 
 	return nil, nil
+}
+
+func UnparseKokiNativeObject(kokiObj interface{}) (map[string]interface{}, error) {
+	// Marshal the koki object back into yaml.
+	bytes, err := yaml.Marshal(kokiObj)
+	if err != nil {
+		return nil, err
+	}
+
+	obj := map[string]interface{}{}
+	err = yaml.Unmarshal(bytes, &obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return obj, err
 }

--- a/parser/native.go
+++ b/parser/native.go
@@ -52,6 +52,10 @@ func ParseKokiNativeObject(obj interface{}) (interface{}, error) {
 			service := &types.ServiceWrapper{}
 			err := json.Unmarshal(bytes, service)
 			return service, err
+		case "volume":
+			volume := &types.VolumeWrapper{}
+			err := json.Unmarshal(bytes, volume)
+			return volume, err
 		}
 
 		return nil, util.TypeValueErrorf(objMap, "Unexpected value %s", k)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -32,11 +32,11 @@ func Parse(filenames []string, useStdin bool) ([]map[string]interface{}, error) 
 	}
 
 	glog.V(3).Info("decoding input data")
-	return parseStream(streams)
+	return parseStreams(streams)
 }
 
 //parses the stream into a go object and closes the stream once done
-func parseStream(streams []io.ReadCloser) ([]map[string]interface{}, error) {
+func parseStreams(streams []io.ReadCloser) ([]map[string]interface{}, error) {
 	structs := []map[string]interface{}{}
 
 	for i := range streams {

--- a/types/pod.go
+++ b/types/pod.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,6 +16,7 @@ type Pod struct {
 	Namespace              string            `json:"namespace,omitempty"`
 	Labels                 map[string]string `json:"labels,omitempty"`
 	Annotations            map[string]string `json:"annotations,omitempty"`
+	Volumes                []v1.Volume       `json:"volumes,omitempty"`
 	Affinity               []Affinity        `json:"affinity,omitempty"`
 	Containers             []Container       `json:"containers,omitempty"`
 	InitContainers         []Container       `json:"init_containers,omitempty"`

--- a/types/volume.go
+++ b/types/volume.go
@@ -1,0 +1,9 @@
+package types
+
+import (
+	"k8s.io/api/core/v1"
+)
+
+type VolumeWrapper struct {
+	Volume v1.Volume `json:"volume"`
+}


### PR DESCRIPTION
Import syntax for shorthand.
Simple parameterization for Pod, Service, RC/RS, Deployment.
Framework allows for addition of parameterization features.

```
imports:
- otherVol: volume0.yaml
- deployment: ../deployment/example1.short.yaml
  params:
    pod: ${pod}
- pod: ../pods/example2.short.yaml
  params:
    name: podName0
    containers.nginx.volumeMounts: ${otherVol}
---
${deployment}
```

becomes

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  creationTimestamp: null
  labels:
    app: example
  name: example-deployment
spec:
  replicas: 3
  strategy:
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        name: podName0
      name: podName0
    spec:
      containers:
      - image: nginx
        name: nginx
        ports:
        - containerPort: 80
          protocol: TCP
        readinessProbe:
          initialDelaySeconds: 5
          timeoutSeconds: 5
        resources: {}
        volumeMounts:
        - mountPath: /emptydir
          mountPropagation: ""
          name: emptydir
      volumes:
      - emptyDir: {}
        name: emptydir
status: {}
```

@wlan0 