### PR TITLE
flattening Template and tweaking fields in RC/RS/Deployment

### DIFF
--- a/cmd/short.go
+++ b/cmd/short.go
@@ -25,6 +25,10 @@ func loadKokiFiles(filenames []string) ([]interface{}, error) {
 			return nil, err
 		}
 
+		if err, ok := module.TypedResult.(error); ok {
+			return nil, err
+		}
+
 		results = append(results, module.TypedResult)
 	}
 

--- a/converter/converters/koki_deployment_to_kube_v1beta1_deployment.go
+++ b/converter/converters/koki_deployment_to_kube_v1beta1_deployment.go
@@ -30,7 +30,7 @@ func Convert_Koki_Deployment_to_Kube_v1beta1_Deployment(deployment *types.Deploy
 	if kokiDeployment.TemplateMetadata != nil {
 		kokiTemplateLabels = kokiDeployment.TemplateMetadata.Labels
 	}
-	kubeSpec.Selector, templateLabelsOverride, err = revertRSSelector(kokiDeployment.Selector, kokiTemplateLabels)
+	kubeSpec.Selector, templateLabelsOverride, err = revertRSSelector(kokiDeployment.Name, kokiDeployment.Selector, kokiTemplateLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/converter/converters/koki_deployment_to_kube_v1beta1_deployment.go
+++ b/converter/converters/koki_deployment_to_kube_v1beta1_deployment.go
@@ -4,6 +4,7 @@ import (
 	exts "k8s.io/api/extensions/v1beta1"
 
 	"github.com/koki/short/types"
+	"github.com/koki/short/util"
 )
 
 func Convert_Koki_Deployment_to_Kube_v1beta1_Deployment(deployment *types.DeploymentWrapper) (*exts.Deployment, error) {
@@ -22,11 +23,29 @@ func Convert_Koki_Deployment_to_Kube_v1beta1_Deployment(deployment *types.Deploy
 	kubeSpec := &kubeDeployment.Spec
 	kubeSpec.Replicas = kokiDeployment.Replicas
 
-	kubeTemplate, err := revertTemplate(&kokiDeployment.Template)
+	// Setting the Selector and Template is identical to ReplicaSet
+
+	var templateLabelsOverride map[string]string
+	var kokiTemplateLabels map[string]string
+	if kokiDeployment.TemplateMetadata != nil {
+		kokiTemplateLabels = kokiDeployment.TemplateMetadata.Labels
+	}
+	kubeSpec.Selector, templateLabelsOverride, err = revertRSSelector(kokiDeployment.Selector, kokiTemplateLabels)
 	if err != nil {
 		return nil, err
 	}
+
+	kubeTemplate, err := revertTemplate(kokiDeployment.GetTemplate())
+	if err != nil {
+		return nil, err
+	}
+	if kubeTemplate == nil {
+		return nil, util.TypeValueErrorf(kokiDeployment, "missing pod template")
+	}
+	kubeTemplate.Labels = templateLabelsOverride
 	kubeSpec.Template = *kubeTemplate
+
+	// End Selector/Template section.
 
 	kubeSpec.Strategy = revertDeploymentStrategy(kokiDeployment)
 

--- a/converter/converters/koki_rc_to_kube_v1_rc.go
+++ b/converter/converters/koki_rc_to_kube_v1_rc.go
@@ -19,12 +19,14 @@ func Convert_Koki_ReplicationController_to_Kube_v1_ReplicationController(rc *typ
 	kubeRC.Labels = kokiRC.Labels
 	kubeRC.Annotations = kokiRC.Annotations
 
-	kubeRC.Spec.Replicas = kokiRC.Replicas
-	kubeRC.Spec.MinReadySeconds = kokiRC.MinReadySeconds
+	kubeSpec := &kubeRC.Spec
+	kubeSpec.Replicas = kokiRC.Replicas
+	kubeSpec.MinReadySeconds = kokiRC.MinReadySeconds
 
-	// We won't repopulate kubeRC.Spec.Selector because it's
+	// We won't repopulate kubeSpec.Selector because it's
 	// defaulted to the Template's labels.
-	kubeRC.Spec.Template, err = revertTemplate(kokiRC.Template)
+	kokiPod := kokiRC.GetTemplate()
+	kubeSpec.Template, err = revertTemplate(kokiPod)
 	if err != nil {
 		return nil, err
 	}

--- a/converter/converters/koki_rc_to_kube_v1_rc.go
+++ b/converter/converters/koki_rc_to_kube_v1_rc.go
@@ -26,6 +26,12 @@ func Convert_Koki_ReplicationController_to_Kube_v1_ReplicationController(rc *typ
 	// We won't repopulate kubeSpec.Selector because it's
 	// defaulted to the Template's labels.
 	kokiPod := kokiRC.GetTemplate()
+	// Make sure there's at least one Label in the Template.
+	if len(kokiPod.Labels) == 0 {
+		kokiPod.Labels = map[string]string{
+			"koki.io/selector.name": kokiRC.Name,
+		}
+	}
 	kubeSpec.Template, err = revertTemplate(kokiPod)
 	if err != nil {
 		return nil, err

--- a/converter/converters/koki_rc_to_kube_v1_rc.go
+++ b/converter/converters/koki_rc_to_kube_v1_rc.go
@@ -21,8 +21,9 @@ func Convert_Koki_ReplicationController_to_Kube_v1_ReplicationController(rc *typ
 
 	kubeRC.Spec.Replicas = kokiRC.Replicas
 	kubeRC.Spec.MinReadySeconds = kokiRC.MinReadySeconds
-	kubeRC.Spec.Selector = kokiRC.PodLabels
 
+	// We won't repopulate kubeRC.Spec.Selector because it's
+	// defaulted to the Template's labels.
 	kubeRC.Spec.Template, err = revertTemplate(kokiRC.Template)
 	if err != nil {
 		return nil, err

--- a/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
+++ b/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
@@ -1,47 +1,93 @@
 package converters
 
 import (
+	"k8s.io/api/core/v1"
 	exts "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	labelselector "github.com/koki/short/converter/converters/affinity"
+	"github.com/koki/short/parser/expressions"
 	"github.com/koki/short/types"
 	"github.com/koki/short/util"
 )
 
-func Convert_Koki_ReplicaSet_to_Kube_v1beta2_ReplicaSet(rc *types.ReplicaSetWrapper) (*exts.ReplicaSet, error) {
+func Convert_Koki_ReplicaSet_to_Kube_v1beta2_ReplicaSet(rs *types.ReplicaSetWrapper) (*exts.ReplicaSet, error) {
 	var err error
-	kubeRC := &exts.ReplicaSet{}
-	kokiRC := rc.ReplicaSet
+	kubeRS := &exts.ReplicaSet{}
+	kokiRS := &rs.ReplicaSet
 
-	kubeRC.Name = kokiRC.Name
-	kubeRC.Namespace = kokiRC.Namespace
-	kubeRC.APIVersion = kokiRC.Version
-	kubeRC.Kind = "ReplicaSet"
-	kubeRC.ClusterName = kokiRC.Cluster
-	kubeRC.Labels = kokiRC.Labels
-	kubeRC.Annotations = kokiRC.Annotations
+	kubeRS.Name = kokiRS.Name
+	kubeRS.Namespace = kokiRS.Namespace
+	kubeRS.APIVersion = kokiRS.Version
+	kubeRS.Kind = "ReplicaSet"
+	kubeRS.ClusterName = kokiRS.Cluster
+	kubeRS.Labels = kokiRS.Labels
+	kubeRS.Annotations = kokiRS.Annotations
 
-	kubeRC.Spec.Replicas = kokiRC.Replicas
-	kubeRC.Spec.MinReadySeconds = kokiRC.MinReadySeconds
-	kubeRC.Spec.Selector, err = labelselector.ParseLabelSelector(kokiRC.PodSelector)
+	kubeSpec := &kubeRS.Spec
+	kubeSpec.Replicas = kokiRS.Replicas
+	kubeSpec.MinReadySeconds = kokiRS.MinReadySeconds
+	var templateLabelsOverride map[string]string
+	var kokiTemplateLabels map[string]string
+	if kokiRS.TemplateMetadata != nil {
+		kokiTemplateLabels = kokiRS.TemplateMetadata.Labels
+	}
+	kubeSpec.Selector, templateLabelsOverride, err = revertRSSelector(kokiRS.Selector, kokiTemplateLabels)
 	if err != nil {
 		return nil, err
 	}
 
-	kubeTemplate, err := revertTemplate(kokiRC.Template)
+	kubeTemplate, err := revertRSTemplate(kokiRS)
 	if err != nil {
 		return nil, err
 	}
-
 	if kubeTemplate == nil {
-		return nil, util.TypeValueErrorf(kokiRC, "missing pod template")
+		return nil, util.TypeValueErrorf(kokiRS, "missing pod template")
+	}
+	kubeTemplate.Labels = templateLabelsOverride
+	kubeSpec.Template = *kubeTemplate
+
+	// Make sure the Selector and the Template.Labels are set correctly.
+	if len(kubeSpec.Template.Labels) == 0 {
 	}
 
-	kubeRC.Spec.Template = *kubeTemplate
-
-	if kokiRC.Status != nil {
-		kubeRC.Status = *kokiRC.Status
+	if kokiRS.Status != nil {
+		kubeRS.Status = *kokiRS.Status
 	}
 
-	return kubeRC, nil
+	return kubeRS, nil
+}
+
+func revertRSSelector(selector *types.RSSelector, templateLabels map[string]string) (*metav1.LabelSelector, map[string]string, error) {
+	if selector == nil {
+		return nil, nil, util.PrettyTypeError(selector, "Selector is required for ReplicaSet")
+	}
+
+	if len(selector.Shorthand) > 0 {
+		labelSelector, err := expressions.ParseLabelSelector(selector.Shorthand)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(templateLabels) == 0 && len(labelSelector.MatchExpressions) == 0 {
+			// Selector is only Labels, and Template.Labels is empty.
+			// Push the Selector Labels down into the Template.
+			return nil, labelSelector.MatchLabels, nil
+		}
+
+		// Can't push the Selector down into the Template.
+		return labelSelector, templateLabels, nil
+	}
+
+	if len(templateLabels) == 0 {
+		// Push the Selector Labels down into the Template.
+		return nil, selector.Labels, nil
+	}
+
+	// Can't push the Selector down into the Template.
+	return &metav1.LabelSelector{
+		MatchLabels: selector.Labels,
+	}, templateLabels, nil
+}
+
+func revertRSTemplate(kokiRS *types.ReplicaSet) (*v1.PodTemplateSpec, error) {
+	return revertTemplate(kokiRS.GetTemplate())
 }

--- a/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
+++ b/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
@@ -10,7 +10,7 @@ import (
 	"github.com/koki/short/util"
 )
 
-func Convert_Koki_ReplicaSet_to_Kube_v1beta2_ReplicaSet(rs *types.ReplicaSetWrapper) (*exts.ReplicaSet, error) {
+func Convert_Koki_ReplicaSet_to_Kube_v1beta1_ReplicaSet(rs *types.ReplicaSetWrapper) (*exts.ReplicaSet, error) {
 	var err error
 	kubeRS := &exts.ReplicaSet{}
 	kokiRS := &rs.ReplicaSet
@@ -26,6 +26,7 @@ func Convert_Koki_ReplicaSet_to_Kube_v1beta2_ReplicaSet(rs *types.ReplicaSetWrap
 	kubeSpec := &kubeRS.Spec
 	kubeSpec.Replicas = kokiRS.Replicas
 	kubeSpec.MinReadySeconds = kokiRS.MinReadySeconds
+
 	var templateLabelsOverride map[string]string
 	var kokiTemplateLabels map[string]string
 	if kokiRS.TemplateMetadata != nil {

--- a/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
+++ b/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
@@ -31,7 +31,7 @@ func Convert_Koki_ReplicaSet_to_Kube_v1beta1_ReplicaSet(rs *types.ReplicaSetWrap
 	if kokiRS.TemplateMetadata != nil {
 		kokiTemplateLabels = kokiRS.TemplateMetadata.Labels
 	}
-	kubeSpec.Selector, templateLabelsOverride, err = revertRSSelector(kokiRS.Selector, kokiTemplateLabels)
+	kubeSpec.Selector, templateLabelsOverride, err = revertRSSelector(kokiRS.Name, kokiRS.Selector, kokiTemplateLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -57,9 +57,11 @@ func Convert_Koki_ReplicaSet_to_Kube_v1beta1_ReplicaSet(rs *types.ReplicaSetWrap
 	return kubeRS, nil
 }
 
-func revertRSSelector(selector *types.RSSelector, templateLabels map[string]string) (*metav1.LabelSelector, map[string]string, error) {
+func revertRSSelector(name string, selector *types.RSSelector, templateLabels map[string]string) (*metav1.LabelSelector, map[string]string, error) {
 	if selector == nil {
-		return nil, nil, util.PrettyTypeError(selector, "Selector is required for ReplicaSet")
+		return nil, map[string]string{
+			"koki.io/selector.name": name,
+		}, nil
 	}
 
 	if len(selector.Shorthand) > 0 {

--- a/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
+++ b/converter/converters/koki_replicaset_to_kube_v1beta1_replicaset.go
@@ -1,7 +1,6 @@
 package converters
 
 import (
-	"k8s.io/api/core/v1"
 	exts "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -37,7 +36,7 @@ func Convert_Koki_ReplicaSet_to_Kube_v1beta1_ReplicaSet(rs *types.ReplicaSetWrap
 		return nil, err
 	}
 
-	kubeTemplate, err := revertRSTemplate(kokiRS)
+	kubeTemplate, err := revertTemplate(kokiRS.GetTemplate())
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +86,4 @@ func revertRSSelector(selector *types.RSSelector, templateLabels map[string]stri
 	return &metav1.LabelSelector{
 		MatchLabels: selector.Labels,
 	}, templateLabels, nil
-}
-
-func revertRSTemplate(kokiRS *types.ReplicaSet) (*v1.PodTemplateSpec, error) {
-	return revertTemplate(kokiRS.GetTemplate())
 }

--- a/converter/converters/kube_v1_pod_to_koki.go
+++ b/converter/converters/kube_v1_pod_to_koki.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/koki/short/parser/expressions"
 	"github.com/koki/short/types"
 	"github.com/koki/short/util"
 )
@@ -767,7 +768,7 @@ func convertPodWeightedAffinityTerms(prefix string, podSoftAffinity []v1.Weighte
 			for i := range selectorTerm.PodAffinityTerm.LabelSelector.MatchExpressions {
 				expr := selectorTerm.PodAffinityTerm.LabelSelector.MatchExpressions[i]
 				value := strings.Join(expr.Values, ",")
-				op, err := convertOperatorLabelSelector(expr.Operator)
+				op, err := expressions.ConvertOperatorLabelSelector(expr.Operator)
 				if err != nil {
 					return nil, err
 				}
@@ -827,7 +828,7 @@ func convertPodAffinityTerms(prefix string, podHardAffinity []v1.PodAffinityTerm
 			for i := range selectorTerm.LabelSelector.MatchExpressions {
 				expr := selectorTerm.LabelSelector.MatchExpressions[i]
 				value := strings.Join(expr.Values, ",")
-				op, err := convertOperatorLabelSelector(expr.Operator)
+				op, err := expressions.ConvertOperatorLabelSelector(expr.Operator)
 				if err != nil {
 					return nil, err
 				}
@@ -883,25 +884,6 @@ func convertOperator(op v1.NodeSelectorOperator) (string, error) {
 	}
 	if op == v1.NodeSelectorOpLt {
 		return "<", nil
-	}
-	return "", util.TypeValueErrorf(op, "Unexpected value %s", op)
-}
-
-func convertOperatorLabelSelector(op metav1.LabelSelectorOperator) (string, error) {
-	if op == "" {
-		return "", nil
-	}
-	if op == metav1.LabelSelectorOpIn {
-		return "=", nil
-	}
-	if op == metav1.LabelSelectorOpNotIn {
-		return "!=", nil
-	}
-	if op == metav1.LabelSelectorOpExists {
-		return "", nil
-	}
-	if op == metav1.LabelSelectorOpDoesNotExist {
-		return "", nil
 	}
 	return "", util.TypeValueErrorf(op, "Unexpected value %s", op)
 }

--- a/converter/converters/kube_v1_rc_to_koki_rc.go
+++ b/converter/converters/kube_v1_rc_to_koki_rc.go
@@ -19,12 +19,16 @@ func Convert_Kube_v1_ReplicationController_to_Koki_ReplicationController(kubeRC 
 	kokiRC.Labels = kubeRC.Labels
 	kokiRC.Annotations = kubeRC.Annotations
 
-	kokiRC.Replicas = kubeRC.Spec.Replicas
-	kokiRC.MinReadySeconds = kubeRC.Spec.MinReadySeconds
-	kokiRC.Template, err = convertTemplate(kubeRC.Spec.Template, kubeRC.Spec.Selector, kubeRC.Name)
+	kubeSpec := &kubeRC.Spec
+
+	kokiRC.Replicas = kubeSpec.Replicas
+	kokiRC.MinReadySeconds = kubeSpec.MinReadySeconds
+
+	kokiPod, err := convertRSTemplate(kubeSpec.Template)
 	if err != nil {
 		return nil, err
 	}
+	kokiRC.SetTemplate(kokiPod)
 
 	if !reflect.DeepEqual(kubeRC.Status, v1.ReplicationControllerStatus{}) {
 		kokiRC.Status = &kubeRC.Status
@@ -33,37 +37,4 @@ func Convert_Kube_v1_ReplicationController_to_Koki_ReplicationController(kubeRC 
 	return &types.ReplicationControllerWrapper{
 		ReplicationController: *kokiRC,
 	}, nil
-}
-
-func convertTemplate(kubeTemplate *v1.PodTemplateSpec, selector map[string]string, parentName string) (*types.Pod, error) {
-	if kubeTemplate == nil {
-		return nil, nil
-	}
-
-	kubePod := &v1.Pod{
-		Spec: kubeTemplate.Spec,
-	}
-
-	kubePod.Name = kubeTemplate.Name
-	kubePod.Namespace = kubeTemplate.Namespace
-	kubePod.Labels = kubeTemplate.Labels
-	kubePod.Annotations = kubeTemplate.Annotations
-
-	if len(kubePod.Labels) == 0 {
-		// If the template doesn't already specify a selector, try filling it from elsewhere.
-		if len(selector) > 0 {
-			kubePod.Labels = selector
-		} else {
-			kubePod.Labels = map[string]string{
-				"koki.io/selector.name": parentName,
-			}
-		}
-	}
-
-	kokiPod, err := Convert_Kube_v1_Pod_to_Koki_Pod(kubePod)
-	if err != nil {
-		return nil, err
-	}
-
-	return &kokiPod.Pod, nil
 }

--- a/converter/converters/kube_v1beta1_deployment_to_koki_deployment.go
+++ b/converter/converters/kube_v1beta1_deployment_to_koki_deployment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/koki/short/types"
 )
 
-func Convert_Kube_v1beta2_Deployment_to_Koki_Deployment(kubeDeployment *exts.Deployment) (*types.DeploymentWrapper, error) {
+func Convert_Kube_v1beta1_Deployment_to_Koki_Deployment(kubeDeployment *exts.Deployment) (*types.DeploymentWrapper, error) {
 	var err error
 	kokiDeployment := &types.Deployment{}
 

--- a/converter/converters/kube_v1beta1_deployment_to_koki_deployment.go
+++ b/converter/converters/kube_v1beta1_deployment_to_koki_deployment.go
@@ -22,7 +22,7 @@ func Convert_Kube_v1beta2_Deployment_to_Koki_Deployment(kubeDeployment *exts.Dep
 
 	kubeSpec := &kubeDeployment.Spec
 	kokiDeployment.Replicas = kubeSpec.Replicas
-	kokiTemplate, err := convertTemplate(&kubeSpec.Template)
+	kokiTemplate, err := convertRSTemplate(&kubeSpec.Template)
 	if err != nil {
 		return nil, err
 	}

--- a/converter/converters/kube_v1beta1_replicaset_to_koki_replicaset.go
+++ b/converter/converters/kube_v1beta1_replicaset_to_koki_replicaset.go
@@ -11,7 +11,7 @@ import (
 	"github.com/koki/short/types"
 )
 
-func Convert_Kube_v1beta2_ReplicaSet_to_Koki_ReplicaSet(kubeRS *exts.ReplicaSet) (*types.ReplicaSetWrapper, error) {
+func Convert_Kube_v1beta1_ReplicaSet_to_Koki_ReplicaSet(kubeRS *exts.ReplicaSet) (*types.ReplicaSetWrapper, error) {
 	var err error
 	kokiRS := &types.ReplicaSet{}
 

--- a/converter/converters/kube_v1beta1_replicaset_to_koki_replicaset.go
+++ b/converter/converters/kube_v1beta1_replicaset_to_koki_replicaset.go
@@ -1,13 +1,13 @@
 package converters
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 
+	"k8s.io/api/core/v1"
 	exts "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/koki/short/parser/expressions"
 	"github.com/koki/short/types"
 )
 
@@ -22,17 +22,26 @@ func Convert_Kube_v1beta2_ReplicaSet_to_Koki_ReplicaSet(kubeRS *exts.ReplicaSet)
 	kokiRS.Labels = kubeRS.Labels
 	kokiRS.Annotations = kubeRS.Annotations
 
-	kokiRS.Replicas = kubeRS.Spec.Replicas
-	kokiRS.MinReadySeconds = kubeRS.Spec.MinReadySeconds
-	kokiRS.PodSelector, err = convertLabelSelector(kubeRS.Spec.Selector)
+	kubeSpec := &kubeRS.Spec
+
+	kokiRS.Replicas = kubeSpec.Replicas
+	kokiRS.MinReadySeconds = kubeSpec.MinReadySeconds
+
+	// Fill out the Selector and Template.Labels.
+	// If kubeRS only has Template.Labels, we only set Selector (because it's at a higher level in the yaml).
+	var templateLabelsOverride map[string]string
+	kokiRS.Selector, templateLabelsOverride, err = convertRSLabelSelector(kubeSpec.Selector, kubeSpec.Template.Labels)
 	if err != nil {
 		return nil, err
 	}
 
-	kokiRS.Template, err = convertTemplate(&kubeRS.Spec.Template)
+	// Build a Pod from the kube Template. Use it to set the koki Template.
+	kokiPod, err := convertRSTemplate(&kubeSpec.Template)
 	if err != nil {
 		return nil, err
 	}
+	kokiPod.Labels = templateLabelsOverride
+	kokiRS.SetTemplate(kokiPod)
 
 	if !reflect.DeepEqual(kubeRS.Status, exts.ReplicaSetStatus{}) {
 		kokiRS.Status = &kubeRS.Status
@@ -43,44 +52,48 @@ func Convert_Kube_v1beta2_ReplicaSet_to_Koki_ReplicaSet(kubeRS *exts.ReplicaSet)
 	}, nil
 }
 
-func convertLabelSelector(kubeSelector *metav1.LabelSelector) (string, error) {
+func convertRSTemplate(kubeTemplate *v1.PodTemplateSpec) (*types.Pod, error) {
+	if kubeTemplate == nil {
+		return nil, nil
+	}
+
+	kubePod := &v1.Pod{
+		Spec: kubeTemplate.Spec,
+	}
+
+	kubePod.Name = kubeTemplate.Name
+	kubePod.Namespace = kubeTemplate.Namespace
+	kubePod.Labels = kubeTemplate.Labels
+	kubePod.Annotations = kubeTemplate.Annotations
+
+	kokiPod, err := Convert_Kube_v1_Pod_to_Koki_Pod(kubePod)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kokiPod.Pod, nil
+}
+
+func convertRSLabelSelector(kubeSelector *metav1.LabelSelector, kubeTemplateLabels map[string]string) (*types.RSSelector, map[string]string, error) {
+	// If the Selector is unspecified, it defaults to the Template's Labels.
 	if kubeSelector == nil {
-		return "", nil
+		return &types.RSSelector{
+			Labels: kubeTemplateLabels,
+		}, nil, nil
 	}
 
-	affinityString := ""
-	// parse through match labels first
-	for k, v := range kubeSelector.MatchLabels {
-		kokiExpr := fmt.Sprintf("%s=%s", k, v)
-		if len(affinityString) > 0 {
-			affinityString = fmt.Sprintf("%s&%s", affinityString, kokiExpr)
-		} else {
-			affinityString = kokiExpr
-		}
+	if len(kubeSelector.MatchExpressions) == 0 {
+		return &types.RSSelector{
+			Labels: kubeSelector.MatchLabels,
+		}, kubeTemplateLabels, nil
 	}
 
-	// parse through match expressions now
-	for i := range kubeSelector.MatchExpressions {
-		expr := kubeSelector.MatchExpressions[i]
-		value := strings.Join(expr.Values, ",")
-		op, err := convertOperatorLabelSelector(expr.Operator)
-		if err != nil {
-			return "", err
-		}
-		kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
-		if expr.Operator == metav1.LabelSelectorOpExists {
-			kokiExpr = fmt.Sprintf("%s", expr.Key)
-		}
-		if expr.Operator == metav1.LabelSelectorOpDoesNotExist {
-			kokiExpr = fmt.Sprintf("!%s", expr.Key)
-		}
-
-		if len(affinityString) > 0 {
-			affinityString = fmt.Sprintf("%s&%s", affinityString, kokiExpr)
-		} else {
-			affinityString = kokiExpr
-		}
+	selectorString, err := expressions.UnparseLabelSelector(kubeSelector)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return affinityString, nil
+	return &types.RSSelector{
+		Shorthand: selectorString,
+	}, kubeTemplateLabels, nil
 }

--- a/converter/koki_converter.go
+++ b/converter/koki_converter.go
@@ -23,7 +23,7 @@ func DetectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
 	case *types.ReplicationControllerWrapper:
 		return converters.Convert_Koki_ReplicationController_to_Kube_v1_ReplicationController(kokiObj)
 	case *types.ReplicaSetWrapper:
-		return converters.Convert_Koki_ReplicaSet_to_Kube_v1beta2_ReplicaSet(kokiObj)
+		return converters.Convert_Koki_ReplicaSet_to_Kube_v1beta1_ReplicaSet(kokiObj)
 	case *types.ServiceWrapper:
 		return converters.Convert_Koki_Service_To_Kube_v1_Service(kokiObj)
 	case *types.VolumeWrapper:
@@ -36,7 +36,7 @@ func DetectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
 func DetectAndConvertFromKubeObj(kubeObj runtime.Object) (interface{}, error) {
 	switch kubeObj := kubeObj.(type) {
 	case *exts.Deployment:
-		return converters.Convert_Kube_v1beta2_Deployment_to_Koki_Deployment(kubeObj)
+		return converters.Convert_Kube_v1beta1_Deployment_to_Koki_Deployment(kubeObj)
 	case *v1.PersistentVolume:
 		return converters.Convert_Kube_v1_PersistentVolume_to_Koki_PersistentVolume(kubeObj)
 	case *v1.Pod:
@@ -44,7 +44,7 @@ func DetectAndConvertFromKubeObj(kubeObj runtime.Object) (interface{}, error) {
 	case *v1.ReplicationController:
 		return converters.Convert_Kube_v1_ReplicationController_to_Koki_ReplicationController(kubeObj)
 	case *exts.ReplicaSet:
-		return converters.Convert_Kube_v1beta2_ReplicaSet_to_Koki_ReplicaSet(kubeObj)
+		return converters.Convert_Kube_v1beta1_ReplicaSet_to_Koki_ReplicaSet(kubeObj)
 	case *v1.Service:
 		return converters.Convert_Kube_v1_Service_to_Koki_Service(kubeObj)
 

--- a/examples/deployment/example1.short.yaml
+++ b/examples/deployment/example1.short.yaml
@@ -1,15 +1,14 @@
 deployment:
+  containers:
+  - expose:
+    - port_map: "80"
+      protocol: TCP
+    image: example/example:latest
+    name: example-app
   labels:
     app: example
   name: example-deployment
   replicas: 3
-  template:
-    containers:
-    - expose:
-      - port_map: "80"
-        protocol: TCP
-      image: example/example:latest
-      name: example-app
-    labels:
-      app: example
+  selector:
+    app: example
   version: extensions/v1beta1

--- a/examples/deployment/example2.short.yaml
+++ b/examples/deployment/example2.short.yaml
@@ -1,19 +1,18 @@
 deployment:
+  containers:
+  - expose:
+    - port_map: "80"
+      protocol: TCP
+    image: example/example:latest
+    name: example-app
   labels:
     app: example
   maxSurge: 130%
   maxUnavailable: 50%
   name: example-deployment
   replicas: 3
+  selector:
+    app: example
   status:
     replicas: 1
-  template:
-    containers:
-    - expose:
-      - port_map: "80"
-        protocol: TCP
-      image: example/example:latest
-      name: example-app
-    labels:
-      app: example
   version: extensions/v1beta1

--- a/examples/deployment/example2.short.yaml
+++ b/examples/deployment/example2.short.yaml
@@ -7,8 +7,8 @@ deployment:
     name: example-app
   labels:
     app: example
-  maxSurge: 130%
-  maxUnavailable: 50%
+  max_extra: 2
+  max_unavailable: 2
   name: example-deployment
   replicas: 3
   selector:

--- a/examples/deployment/example2.yaml
+++ b/examples/deployment/example2.yaml
@@ -11,8 +11,8 @@ spec:
       app: example
   strategy:
     rollingUpdate:
-      maxUnavailable: 50%
-      maxSurge: 130%
+      maxUnavailable: 2
+      maxSurge: 2
   template:
     metadata:
       labels:

--- a/examples/deployment/example3.short.yaml
+++ b/examples/deployment/example3.short.yaml
@@ -1,0 +1,17 @@
+deployment:
+  containers:
+  - expose:
+    - port_map: "80"
+      protocol: TCP
+    image: example/example:latest
+    name: example-app
+  labels:
+    app: example
+  max_extra: 2
+  max_unavailable: 2
+  name: example-deployment
+  replicas: 3
+  selector: null
+  status:
+    replicas: 1
+  version: extensions/v1beta1

--- a/examples/deployment/example3.yaml
+++ b/examples/deployment/example3.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: example-deployment
+  labels:
+    app: example
+spec:
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 2
+      maxSurge: 2
+  template:
+    metadata:
+      labels:
+        koki.io/selector.name: example-deployment
+    spec:
+      containers:
+      - name: example-app
+        image: example/example:latest
+        ports:
+        - containerPort: 80
+status:
+  replicas: 1

--- a/examples/rc/example1.short.yaml
+++ b/examples/rc/example1.short.yaml
@@ -1,15 +1,13 @@
-replicationController:
+replication_controller:
+  containers:
+  - image: gcr.io/kuard-demo/kuard-amd64:1
+    name: kuard
   labels:
     component: example
   name: example
-  podLabels:
+  replicas: 1
+  selector:
     key0: value0
     key1: value1
-  replicas: 1
-  template:
-    containers:
-    - image: gcr.io/kuard-demo/kuard-amd64:1
-      name: kuard
-    labels:
-      component: example
   version: v1
+

--- a/examples/rc/example1.yaml
+++ b/examples/rc/example1.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  creationTimestamp: null
   labels:
     component: example
   name: example
@@ -12,9 +11,9 @@ spec:
     key1: value1
   template:
     metadata:
-      creationTimestamp: null
       labels:
-        component: example
+        key0: value0
+        key1: value1
     spec:
       containers:
       - image: gcr.io/kuard-demo/kuard-amd64:1

--- a/examples/rc/example2.short.yaml
+++ b/examples/rc/example2.short.yaml
@@ -1,0 +1,9 @@
+replication_controller:
+  containers:
+  - image: gcr.io/kuard-demo/kuard-amd64:1
+    name: kuard
+  labels:
+    component: example
+  name: example
+  replicas: 1
+  version: v1

--- a/examples/rc/example2.yaml
+++ b/examples/rc/example2.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    component: example
+  name: example
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        koki.io/selector.name: example
+    spec:
+      containers:
+      - image: gcr.io/kuard-demo/kuard-amd64:1
+        name: kuard
+        resources: {}

--- a/examples/rc/f1.short.yaml
+++ b/examples/rc/f1.short.yaml
@@ -1,33 +1,35 @@
-replicationController:
+replication_controller:
+  containers:
+  - cap_add:
+    - IPC_LOCK
+    env:
+    - val: KUBERNETES_CA_CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    - from: metadata.namespace
+      val: NAMESPACE
+    - val: CLUSTER_NAME=myesdb
+    - val: DISCOVERY_SERVICE=elasticsearch
+    - val: NODE_MASTER=true
+    - val: NODE_DATA=true
+    - val: HTTP_ENABLE=true
+    expose:
+    - name: http
+      port_map: "9200"
+      protocol: TCP
+    - name: transport
+      port_map: "9300"
+      protocol: TCP
+    image: quay.io/pires/docker-elasticsearch-kubernetes:1.7.1-4
+    name: es
+    volume:
+    - mount: /data
+      store: storage
   labels:
     component: elasticsearch
   name: es
   replicas: 1
-  template:
-    containers:
-    - cap_add:
-      - IPC_LOCK
-      env:
-      - val: KUBERNETES_CA_CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      - from: metadata.namespace
-        val: NAMESPACE
-      - val: CLUSTER_NAME=myesdb
-      - val: DISCOVERY_SERVICE=elasticsearch
-      - val: NODE_MASTER=true
-      - val: NODE_DATA=true
-      - val: HTTP_ENABLE=true
-      expose:
-      - name: http
-        port_map: "9200"
-        protocol: TCP
-      - name: transport
-        port_map: "9300"
-        protocol: TCP
-      image: quay.io/pires/docker-elasticsearch-kubernetes:1.7.1-4
-      name: es
-      volume:
-      - mount: /data
-        store: storage
-    labels:
-      component: elasticsearch
+  selector:
+    component: elasticsearch
   version: v1
+  volumes:
+  - emptyDir: {}
+    name: storage

--- a/examples/replicaset/example1.short.yaml
+++ b/examples/replicaset/example1.short.yaml
@@ -6,11 +6,11 @@ replica_set:
   replicas: 1
   containers:
   - image: gcr.io/kuard-demo/kuard-amd64:1
-    imagePullPolicy: IfNotPresent
+    pull: IfNotPresent
     name: kuard
     resources: {}
-  dnsPolicy: ClusterFirst
-  restartPolicy: Never
+  dns_policy: ClusterFirst
+  restart_policy: Never
   pod_meta:
     labels:
       component: example

--- a/examples/replicaset/example1.yaml
+++ b/examples/replicaset/example1.yaml
@@ -1,7 +1,6 @@
 apiVersion: extensions/v1beta1
 kind: ReplicaSet
 metadata:
-  creationTimestamp: null
   labels:
     component: example
   name: example
@@ -25,11 +24,13 @@ spec:
       key0: value0
   template:
     metadata:
-      creationTimestamp: null
       labels:
         component: example
     spec:
       containers:
       - image: gcr.io/kuard-demo/kuard-amd64:1
+        imagePullPolicy: IfNotPresent
         name: kuard
         resources: {}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never

--- a/examples/replicaset/example2.short.yaml
+++ b/examples/replicaset/example2.short.yaml
@@ -1,8 +1,7 @@
 replica_set:
-  labels:
-    component: example
   name: example
-  selector: key0=value0&key1=value1,value2&!key2&key3!=value3,value4
+  selector: 
+    component: example
   replicas: 1
   containers:
   - image: gcr.io/kuard-demo/kuard-amd64:1
@@ -11,7 +10,4 @@ replica_set:
     resources: {}
   dnsPolicy: ClusterFirst
   restartPolicy: Never
-  pod_meta:
-    labels:
-      component: example
   version: extensions/v1beta1

--- a/examples/replicaset/example2.short.yaml
+++ b/examples/replicaset/example2.short.yaml
@@ -5,9 +5,9 @@ replica_set:
   replicas: 1
   containers:
   - image: gcr.io/kuard-demo/kuard-amd64:1
-    imagePullPolicy: IfNotPresent
+    pull: IfNotPresent
     name: kuard
     resources: {}
-  dnsPolicy: ClusterFirst
-  restartPolicy: Never
+  dns_policy: ClusterFirst
+  restart_policy: Never
   version: extensions/v1beta1

--- a/examples/replicaset/example2.yaml
+++ b/examples/replicaset/example2.yaml
@@ -11,5 +11,8 @@ spec:
     spec:
       containers:
       - image: gcr.io/kuard-demo/kuard-amd64:1
+        imagePullPolicy: IfNotPresent
         name: kuard
         resources: {}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never

--- a/examples/replicaset/example2.yaml
+++ b/examples/replicaset/example2.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: example
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: example
+    spec:
+      containers:
+      - image: gcr.io/kuard-demo/kuard-amd64:1
+        name: kuard
+        resources: {}

--- a/examples/replicaset/f1.short.yaml
+++ b/examples/replicaset/f1.short.yaml
@@ -1,33 +1,35 @@
-replicaSet:
+replica_set:
+  containers:
+  - cap_add:
+    - IPC_LOCK
+    env:
+    - val: KUBERNETES_CA_CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    - from: metadata.namespace
+      val: NAMESPACE
+    - val: CLUSTER_NAME=myesdb
+    - val: DISCOVERY_SERVICE=elasticsearch
+    - val: NODE_MASTER=true
+    - val: NODE_DATA=true
+    - val: HTTP_ENABLE=true
+    expose:
+    - name: http
+      port_map: "9200"
+      protocol: TCP
+    - name: transport
+      port_map: "9300"
+      protocol: TCP
+    image: quay.io/pires/docker-elasticsearch-kubernetes:1.7.1-4
+    name: es
+    volume:
+    - mount: /data
+      store: storage
   labels:
     component: elasticsearch
   name: es
   replicas: 1
-  template:
-    containers:
-    - cap_add:
-      - IPC_LOCK
-      env:
-      - val: KUBERNETES_CA_CERTIFICATE_FILE=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-      - from: metadata.namespace
-        val: NAMESPACE
-      - val: CLUSTER_NAME=myesdb
-      - val: DISCOVERY_SERVICE=elasticsearch
-      - val: NODE_MASTER=true
-      - val: NODE_DATA=true
-      - val: HTTP_ENABLE=true
-      expose:
-      - name: http
-        port_map: "9200"
-        protocol: TCP
-      - name: transport
-        port_map: "9300"
-        protocol: TCP
-      image: quay.io/pires/docker-elasticsearch-kubernetes:1.7.1-4
-      name: es
-      volume:
-      - mount: /data
-        store: storage
-    labels:
-      component: elasticsearch
+  selector:
+    component: elasticsearch
   version: extensions/v1beta1
+  volumes:
+  - emptyDir: {}
+    name: storage

--- a/param/apply_deployment.go
+++ b/param/apply_deployment.go
@@ -1,41 +1,50 @@
 package param
 
 import (
-	//"github.com/koki/short/parser"
+	"github.com/koki/short/parser"
 	"github.com/koki/short/types"
-	//"github.com/koki/short/util"
+	"github.com/koki/short/util"
 )
 
 func ApplyDeploymentParams(params map[string]interface{}, wrapper *types.DeploymentWrapper) error {
-	/*
-		deployment := &wrapper.Deployment
-		if name, ok := params["name"]; ok {
-			if name, ok := name.(string); ok {
-				deployment.Name = name
-				if deployment.Labels != nil {
-					deployment.Labels["name"] = name
-				} else {
-					deployment.Labels = map[string]string{
-						"name": name,
-					}
+	deployment := &wrapper.Deployment
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			deployment.Name = name
+			if deployment.Labels != nil {
+				deployment.Labels["name"] = name
+			} else {
+				deployment.Labels = map[string]string{
+					"name": name,
+				}
+			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
+		}
+	}
+
+	if pod, ok := params["pod"]; ok {
+		kokiObj, err := parser.ParseKokiNativeObject(pod)
+		if err != nil {
+			return err
+		}
+		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+			// If the Pod has labels, pull them up into the Selector.
+			// Otherwise, automatically set up Selector and Labels on conversion to kube obj.
+			labels := kokiPod.Pod.Labels
+			kokiPod.Pod.Labels = nil
+			deployment.SetTemplate(&kokiPod.Pod)
+			if len(kokiPod.Pod.Labels) > 0 {
+				deployment.Selector = &types.RSSelector{
+					Labels: labels,
 				}
 			} else {
-				return util.PrettyTypeError(params, "expected string for 'name'")
+				deployment.Selector = nil
 			}
+		} else {
+			return util.PrettyTypeError(kokiObj, "expected a pod")
 		}
-
-		if pod, ok := params["pod"]; ok {
-			kokiObj, err := parser.ParseKokiNativeObject(pod)
-			if err != nil {
-				return err
-			}
-			if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
-				deployment.Template = kokiPod.Pod
-			} else {
-				return util.PrettyTypeError(kokiObj, "expected a pod")
-			}
-		}
-	*/
+	}
 
 	return nil
 }

--- a/param/apply_deployment.go
+++ b/param/apply_deployment.go
@@ -1,39 +1,41 @@
 package param
 
 import (
-	"github.com/koki/short/parser"
+	//"github.com/koki/short/parser"
 	"github.com/koki/short/types"
-	"github.com/koki/short/util"
+	//"github.com/koki/short/util"
 )
 
 func ApplyDeploymentParams(params map[string]interface{}, wrapper *types.DeploymentWrapper) error {
-	deployment := &wrapper.Deployment
-	if name, ok := params["name"]; ok {
-		if name, ok := name.(string); ok {
-			deployment.Name = name
-			if deployment.Labels != nil {
-				deployment.Labels["name"] = name
-			} else {
-				deployment.Labels = map[string]string{
-					"name": name,
+	/*
+		deployment := &wrapper.Deployment
+		if name, ok := params["name"]; ok {
+			if name, ok := name.(string); ok {
+				deployment.Name = name
+				if deployment.Labels != nil {
+					deployment.Labels["name"] = name
+				} else {
+					deployment.Labels = map[string]string{
+						"name": name,
+					}
 				}
+			} else {
+				return util.PrettyTypeError(params, "expected string for 'name'")
 			}
-		} else {
-			return util.PrettyTypeError(params, "expected string for 'name'")
 		}
-	}
 
-	if pod, ok := params["pod"]; ok {
-		kokiObj, err := parser.ParseKokiNativeObject(pod)
-		if err != nil {
-			return err
+		if pod, ok := params["pod"]; ok {
+			kokiObj, err := parser.ParseKokiNativeObject(pod)
+			if err != nil {
+				return err
+			}
+			if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+				deployment.Template = kokiPod.Pod
+			} else {
+				return util.PrettyTypeError(kokiObj, "expected a pod")
+			}
 		}
-		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
-			deployment.Template = kokiPod.Pod
-		} else {
-			return util.PrettyTypeError(kokiObj, "expected a pod")
-		}
-	}
+	*/
 
 	return nil
 }

--- a/param/apply_replicaset.go
+++ b/param/apply_replicaset.go
@@ -1,43 +1,50 @@
 package param
 
 import (
-	//"github.com/koki/short/parser"
+	"github.com/koki/short/parser"
 	"github.com/koki/short/types"
-	//"github.com/koki/short/util"
+	"github.com/koki/short/util"
 )
 
 func ApplyReplicaSetParams(params map[string]interface{}, wrapper *types.ReplicaSetWrapper) error {
-	/*
-		replicaSet := &wrapper.ReplicaSet
-		if name, ok := params["name"]; ok {
-			if name, ok := name.(string); ok {
-				replicaSet.Name = name
-				if replicaSet.Labels != nil {
-					replicaSet.Labels["name"] = name
-				} else {
-					replicaSet.Labels = map[string]string{
-						"name": name,
-					}
+	replicaSet := &wrapper.ReplicaSet
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			replicaSet.Name = name
+			if replicaSet.Labels != nil {
+				replicaSet.Labels["name"] = name
+			} else {
+				replicaSet.Labels = map[string]string{
+					"name": name,
+				}
+			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
+		}
+	}
+
+	if pod, ok := params["pod"]; ok {
+		kokiObj, err := parser.ParseKokiNativeObject(pod)
+		if err != nil {
+			return err
+		}
+		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+			// If the Pod has labels, pull them up into the Selector.
+			// Otherwise, automatically set up Selector and Labels on conversion to kube obj.
+			labels := kokiPod.Pod.Labels
+			kokiPod.Pod.Labels = nil
+			replicaSet.SetTemplate(&kokiPod.Pod)
+			if len(kokiPod.Pod.Labels) > 0 {
+				replicaSet.Selector = &types.RSSelector{
+					Labels: labels,
 				}
 			} else {
-				return util.PrettyTypeError(params, "expected string for 'name'")
+				replicaSet.Selector = nil
 			}
+		} else {
+			return util.PrettyTypeError(kokiObj, "expected a pod")
 		}
-
-		if pod, ok := params["pod"]; ok {
-			kokiObj, err := parser.ParseKokiNativeObject(pod)
-			if err != nil {
-				return err
-			}
-			if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
-				replicaSet.Template = &kokiPod.Pod
-				// Empty selector just uses template's labels.
-				replicaSet.PodSelector = ""
-			} else {
-				return util.PrettyTypeError(kokiObj, "expected a pod")
-			}
-		}
-	*/
+	}
 
 	return nil
 }

--- a/param/apply_replicaset.go
+++ b/param/apply_replicaset.go
@@ -1,41 +1,43 @@
 package param
 
 import (
-	"github.com/koki/short/parser"
+	//"github.com/koki/short/parser"
 	"github.com/koki/short/types"
-	"github.com/koki/short/util"
+	//"github.com/koki/short/util"
 )
 
 func ApplyReplicaSetParams(params map[string]interface{}, wrapper *types.ReplicaSetWrapper) error {
-	replicaSet := &wrapper.ReplicaSet
-	if name, ok := params["name"]; ok {
-		if name, ok := name.(string); ok {
-			replicaSet.Name = name
-			if replicaSet.Labels != nil {
-				replicaSet.Labels["name"] = name
-			} else {
-				replicaSet.Labels = map[string]string{
-					"name": name,
+	/*
+		replicaSet := &wrapper.ReplicaSet
+		if name, ok := params["name"]; ok {
+			if name, ok := name.(string); ok {
+				replicaSet.Name = name
+				if replicaSet.Labels != nil {
+					replicaSet.Labels["name"] = name
+				} else {
+					replicaSet.Labels = map[string]string{
+						"name": name,
+					}
 				}
+			} else {
+				return util.PrettyTypeError(params, "expected string for 'name'")
 			}
-		} else {
-			return util.PrettyTypeError(params, "expected string for 'name'")
 		}
-	}
 
-	if pod, ok := params["pod"]; ok {
-		kokiObj, err := parser.ParseKokiNativeObject(pod)
-		if err != nil {
-			return err
+		if pod, ok := params["pod"]; ok {
+			kokiObj, err := parser.ParseKokiNativeObject(pod)
+			if err != nil {
+				return err
+			}
+			if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+				replicaSet.Template = &kokiPod.Pod
+				// Empty selector just uses template's labels.
+				replicaSet.PodSelector = ""
+			} else {
+				return util.PrettyTypeError(kokiObj, "expected a pod")
+			}
 		}
-		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
-			replicaSet.Template = &kokiPod.Pod
-			// Empty selector just uses template's labels.
-			replicaSet.PodSelector = ""
-		} else {
-			return util.PrettyTypeError(kokiObj, "expected a pod")
-		}
-	}
+	*/
 
 	return nil
 }

--- a/param/apply_replicationcontroller.go
+++ b/param/apply_replicationcontroller.go
@@ -1,43 +1,41 @@
 package param
 
 import (
-	//"github.com/koki/short/parser"
+	"github.com/koki/short/parser"
 	"github.com/koki/short/types"
-	//"github.com/koki/short/util"
+	"github.com/koki/short/util"
 )
 
 func ApplyReplicationControllerParams(params map[string]interface{}, wrapper *types.ReplicationControllerWrapper) error {
-	/*
-		rc := &wrapper.ReplicationController
+	rc := &wrapper.ReplicationController
 
-		if name, ok := params["name"]; ok {
-			if name, ok := name.(string); ok {
-				rc.Name = name
-				if rc.Labels != nil {
-					rc.Labels["name"] = name
-				} else {
-					rc.Labels = map[string]string{
-						"name": name,
-					}
+	if name, ok := params["name"]; ok {
+		if name, ok := name.(string); ok {
+			rc.Name = name
+			if rc.Labels != nil {
+				rc.Labels["name"] = name
+			} else {
+				rc.Labels = map[string]string{
+					"name": name,
 				}
-			} else {
-				return util.PrettyTypeError(params, "expected string for 'name'")
 			}
+		} else {
+			return util.PrettyTypeError(params, "expected string for 'name'")
 		}
+	}
 
-		if pod, ok := params["pod"]; ok {
-			kokiObj, err := parser.ParseKokiNativeObject(pod)
-			if err != nil {
-				return err
-			}
-			if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
-				rc.Template = &kokiPod.Pod
-				// Empty selector just uses template's labels.
-				rc.PodLabels = nil
-			} else {
-				return util.PrettyTypeError(kokiObj, "expected a pod")
-			}
+	if pod, ok := params["pod"]; ok {
+		kokiObj, err := parser.ParseKokiNativeObject(pod)
+		if err != nil {
+			return err
 		}
-	*/
+		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+			rc.SetTemplate(&kokiPod.Pod)
+			// We'll either use the Pod's Labels or generate a Selector and Labels on conversion to kube obj.
+			rc.Selector = nil
+		} else {
+			return util.PrettyTypeError(kokiObj, "expected a pod")
+		}
+	}
 	return nil
 }

--- a/param/apply_replicationcontroller.go
+++ b/param/apply_replicationcontroller.go
@@ -1,41 +1,43 @@
 package param
 
 import (
-	"github.com/koki/short/parser"
+	//"github.com/koki/short/parser"
 	"github.com/koki/short/types"
-	"github.com/koki/short/util"
+	//"github.com/koki/short/util"
 )
 
 func ApplyReplicationControllerParams(params map[string]interface{}, wrapper *types.ReplicationControllerWrapper) error {
-	rc := &wrapper.ReplicationController
+	/*
+		rc := &wrapper.ReplicationController
 
-	if name, ok := params["name"]; ok {
-		if name, ok := name.(string); ok {
-			rc.Name = name
-			if rc.Labels != nil {
-				rc.Labels["name"] = name
-			} else {
-				rc.Labels = map[string]string{
-					"name": name,
+		if name, ok := params["name"]; ok {
+			if name, ok := name.(string); ok {
+				rc.Name = name
+				if rc.Labels != nil {
+					rc.Labels["name"] = name
+				} else {
+					rc.Labels = map[string]string{
+						"name": name,
+					}
 				}
+			} else {
+				return util.PrettyTypeError(params, "expected string for 'name'")
 			}
-		} else {
-			return util.PrettyTypeError(params, "expected string for 'name'")
 		}
-	}
 
-	if pod, ok := params["pod"]; ok {
-		kokiObj, err := parser.ParseKokiNativeObject(pod)
-		if err != nil {
-			return err
+		if pod, ok := params["pod"]; ok {
+			kokiObj, err := parser.ParseKokiNativeObject(pod)
+			if err != nil {
+				return err
+			}
+			if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
+				rc.Template = &kokiPod.Pod
+				// Empty selector just uses template's labels.
+				rc.PodLabels = nil
+			} else {
+				return util.PrettyTypeError(kokiObj, "expected a pod")
+			}
 		}
-		if kokiPod, ok := kokiObj.(*types.PodWrapper); ok {
-			rc.Template = &kokiPod.Pod
-			// Empty selector just uses template's labels.
-			rc.PodLabels = nil
-		} else {
-			return util.PrettyTypeError(kokiObj, "expected a pod")
-		}
-	}
+	*/
 	return nil
 }

--- a/parser/expressions/expr.go
+++ b/parser/expressions/expr.go
@@ -1,0 +1,50 @@
+package expressions
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Expr is the generic AST format of a koki NodeSelectorRequirement or LabelSelectorRequirement
+type Expr struct {
+	Key    string
+	Op     string
+	Values []string
+}
+
+func ParseExpr(s string, ops []string) (*Expr, error) {
+	for _, op := range ops {
+		x, err := ParseOp(s, op)
+		if err != nil {
+			return nil, err
+		}
+
+		if x != nil {
+			return x, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func ParseOp(s string, op string) (*Expr, error) {
+	if strings.Contains(s, op) {
+		segs := strings.Split(s, op)
+		if len(segs) != 2 {
+			return nil, fmt.Errorf(
+				"Unrecognized expression (%s), op (%s)", s, op)
+		}
+
+		return &Expr{
+			Key:    segs[0],
+			Op:     op,
+			Values: ParseValues(segs[1]),
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func ParseValues(s string) []string {
+	return strings.Split(s, ",")
+}

--- a/parser/expressions/labelselector.go
+++ b/parser/expressions/labelselector.go
@@ -1,0 +1,138 @@
+package expressions
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/glog"
+
+	"github.com/koki/short/util"
+)
+
+func ParseLabelSelector(s string) (*metav1.LabelSelector, error) {
+	if len(s) == 0 {
+		return nil, nil
+	}
+
+	labels := map[string]string{}
+	reqs := []metav1.LabelSelectorRequirement{}
+	segs := strings.Split(s, "&")
+	for _, seg := range segs {
+		expr, err := ParseExpr(seg, []string{"!=", "="})
+		if err != nil {
+			return nil, err
+		}
+
+		if expr == nil {
+			if seg[0] == '!' {
+				reqs = append(reqs, metav1.LabelSelectorRequirement{
+					Key:      seg[1:],
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				})
+			} else {
+				reqs = append(reqs, metav1.LabelSelectorRequirement{
+					Key:      seg,
+					Operator: metav1.LabelSelectorOpExists,
+				})
+			}
+
+			continue
+		}
+
+		var op metav1.LabelSelectorOperator
+		switch expr.Op {
+		case "=":
+			op = metav1.LabelSelectorOpIn
+		case "!=":
+			op = metav1.LabelSelectorOpNotIn
+		default:
+			glog.Fatal("unreachable")
+		}
+
+		if len(expr.Values) == 1 {
+			labels[expr.Key] = expr.Values[0]
+		} else {
+			reqs = append(reqs, metav1.LabelSelectorRequirement{
+				Key:      expr.Key,
+				Operator: op,
+				Values:   expr.Values,
+			})
+		}
+	}
+
+	if len(labels) == 0 {
+		labels = nil
+	}
+
+	if len(reqs) == 0 {
+		reqs = nil
+	}
+
+	return &metav1.LabelSelector{
+		MatchLabels:      labels,
+		MatchExpressions: reqs,
+	}, nil
+}
+
+func UnparseLabelSelector(kubeSelector *metav1.LabelSelector) (string, error) {
+	if kubeSelector == nil {
+		return "", nil
+	}
+
+	selectorString := ""
+	// parse through match labels first
+	for k, v := range kubeSelector.MatchLabels {
+		kokiExpr := fmt.Sprintf("%s=%s", k, v)
+		if len(selectorString) > 0 {
+			selectorString = fmt.Sprintf("%s&%s", selectorString, kokiExpr)
+		} else {
+			selectorString = kokiExpr
+		}
+	}
+
+	// parse through match expressions now
+	for i := range kubeSelector.MatchExpressions {
+		expr := kubeSelector.MatchExpressions[i]
+		value := strings.Join(expr.Values, ",")
+		op, err := ConvertOperatorLabelSelector(expr.Operator)
+		if err != nil {
+			return "", err
+		}
+		kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
+		if expr.Operator == metav1.LabelSelectorOpExists {
+			kokiExpr = fmt.Sprintf("%s", expr.Key)
+		}
+		if expr.Operator == metav1.LabelSelectorOpDoesNotExist {
+			kokiExpr = fmt.Sprintf("!%s", expr.Key)
+		}
+
+		if len(selectorString) > 0 {
+			selectorString = fmt.Sprintf("%s&%s", selectorString, kokiExpr)
+		} else {
+			selectorString = kokiExpr
+		}
+	}
+
+	return selectorString, nil
+}
+
+func ConvertOperatorLabelSelector(op metav1.LabelSelectorOperator) (string, error) {
+	if op == "" {
+		return "", nil
+	}
+	if op == metav1.LabelSelectorOpIn {
+		return "=", nil
+	}
+	if op == metav1.LabelSelectorOpNotIn {
+		return "!=", nil
+	}
+	if op == metav1.LabelSelectorOpExists {
+		return "", nil
+	}
+	if op == metav1.LabelSelectorOpDoesNotExist {
+		return "", nil
+	}
+	return "", util.TypeValueErrorf(op, "Unexpected value %s", op)
+}

--- a/parser/native.go
+++ b/parser/native.go
@@ -44,7 +44,7 @@ func ParseKokiNativeObject(obj interface{}) (interface{}, error) {
 			replicaSet := &types.ReplicaSetWrapper{}
 			err := json.Unmarshal(bytes, replicaSet)
 			return replicaSet, err
-		case "replicationController":
+		case "replication_controller":
 			replicationController := &types.ReplicationControllerWrapper{}
 			err := json.Unmarshal(bytes, replicationController)
 			return replicationController, err

--- a/parser/native.go
+++ b/parser/native.go
@@ -40,7 +40,7 @@ func ParseKokiNativeObject(obj interface{}) (interface{}, error) {
 			pod := &types.PodWrapper{}
 			err := json.Unmarshal(bytes, pod)
 			return pod, err
-		case "replicaSet":
+		case "replica_set":
 			replicaSet := &types.ReplicaSetWrapper{}
 			err := json.Unmarshal(bytes, replicaSet)
 			return replicaSet, err

--- a/types/deployment.go
+++ b/types/deployment.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"k8s.io/api/core/v1"
 	apps "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -18,7 +20,6 @@ type Deployment struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	Replicas       *int32              `json:"replicas,omitempty"`
-	Template       Pod                 `json:"template"`
 	Recreate       bool                `json:"recreate,omitempty"`
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 	MaxSurge       *intstr.IntOrString `json:"maxSurge,omitempty"`
@@ -29,4 +30,114 @@ type Deployment struct {
 	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty"`
 
 	Status *apps.DeploymentStatus `json:"status,omitempty"`
+
+	// Selector in ReplicaSet can express more complex rules than just matching
+	// pod labels, so it needs its own field (unlike in ReplicationController).
+	// Leaving it blank has the same effect as omitting Selector in RC.
+	Selector *RSSelector `json:"selector,omitempty"`
+
+	// Template fields
+	TemplateMetadata       *RSTemplateMetadata `json:"pod_meta,omitempty"`
+	Volumes                []v1.Volume         `json:"volumes,omitempty"`
+	Affinity               []Affinity          `json:"affinity,omitempty"`
+	Containers             []Container         `json:"containers,omitempty"`
+	InitContainers         []Container         `json:"init_containers,omitempty"`
+	DNSPolicy              DNSPolicy           `json:"dns_policy,omitempty"`
+	HostAliases            []string            `json:"host_aliases,omitempty"`
+	HostMode               []HostMode          `json:"host_mode,omitempty"`
+	Hostname               string              `json:"hostname,omitempty"`
+	Registries             []string            `json:"registry_secrets,omitempty"`
+	RestartPolicy          RestartPolicy       `json:"restart_policy,omitempty"`
+	SchedulerName          string              `json:"scheduler_name,omitempty"`
+	Account                string              `json:"account,omitempty"`
+	Tolerations            []Toleration        `json:"tolerations,omitempty"`
+	TerminationGracePeriod *int64              `json:"termination_grace_period,omitempty"`
+	ActiveDeadline         *int64              `json:"active_deadline,omitempty"`
+	Node                   string              `json:"node,omitempty"`
+	Priority               *Priority           `json:"priority,omitempty"`
+	Conditions             []PodCondition      `json:"condition,omitempty"`
+	NodeIP                 string              `json:"node_ip,omitempty"`
+	StartTime              *metav1.Time        `json:"start_time,omitempty"`
+	Msg                    string              `json:"msg,omitempty"`
+	Phase                  PodPhase            `json:"phase,omitempty"`
+	IP                     string              `json:"ip,omitempty"`
+	QOS                    PodQOSClass         `json:"qos,omitempty"`
+	Reason                 string              `json:"reason,omitempty"`
+	FSGID                  *int64              `json:"fs_gid,omitempty"`
+	GIDs                   []int64             `json:"gids,omitempty"`
+}
+
+func (d *Deployment) SetTemplate(pod *Pod) {
+	d.TemplateMetadata = RSTemplateMetadataFromPod(pod)
+	d.Volumes = pod.Volumes
+	d.Affinity = pod.Affinity
+	d.Containers = pod.Containers
+	d.InitContainers = pod.InitContainers
+	d.DNSPolicy = pod.DNSPolicy
+	d.HostAliases = pod.HostAliases
+	d.HostMode = pod.HostMode
+	d.Hostname = pod.Hostname
+	d.Registries = pod.Registries
+	d.RestartPolicy = pod.RestartPolicy
+	d.SchedulerName = pod.SchedulerName
+	d.Account = pod.Account
+	d.Tolerations = pod.Tolerations
+	d.TerminationGracePeriod = pod.TerminationGracePeriod
+
+	d.ActiveDeadline = pod.ActiveDeadline
+	d.Node = pod.Node
+	d.Priority = pod.Priority
+	d.Conditions = pod.Conditions
+	d.NodeIP = pod.NodeIP
+	d.StartTime = pod.StartTime
+	d.Msg = pod.Msg
+	d.Phase = pod.Phase
+	d.IP = pod.IP
+	d.QOS = pod.QOS
+	d.Reason = pod.Reason
+	d.FSGID = pod.FSGID
+	d.GIDs = pod.GIDs
+}
+
+func (d *Deployment) GetTemplate() *Pod {
+	pod := Pod{}
+
+	if d.TemplateMetadata != nil {
+		pod.Cluster = d.TemplateMetadata.Cluster
+		pod.Name = d.TemplateMetadata.Name
+		pod.Namespace = d.TemplateMetadata.Namespace
+		pod.Labels = d.TemplateMetadata.Labels
+		pod.Annotations = d.TemplateMetadata.Annotations
+	}
+
+	pod.Volumes = d.Volumes
+	pod.Affinity = d.Affinity
+	pod.Containers = d.Containers
+	pod.InitContainers = d.InitContainers
+	pod.DNSPolicy = d.DNSPolicy
+	pod.HostAliases = d.HostAliases
+	pod.HostMode = d.HostMode
+	pod.Hostname = d.Hostname
+	pod.Registries = d.Registries
+	pod.RestartPolicy = d.RestartPolicy
+	pod.SchedulerName = d.SchedulerName
+	pod.Account = d.Account
+	pod.Tolerations = d.Tolerations
+	pod.TerminationGracePeriod = d.TerminationGracePeriod
+
+	pod.ActiveDeadline = d.ActiveDeadline
+	pod.Node = d.Node
+	pod.Priority = d.Priority
+	pod.Conditions = d.Conditions
+	pod.NodeIP = d.NodeIP
+	pod.StartTime = d.StartTime
+	pod.Msg = d.Msg
+	pod.Phase = d.Phase
+	pod.IP = d.IP
+	pod.QOS = d.QOS
+	pod.Reason = d.Reason
+	pod.FSGID = d.FSGID
+	pod.GIDs = d.GIDs
+
+	return &pod
 }

--- a/types/deployment.go
+++ b/types/deployment.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/api/core/v1"
 	apps "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	intstr "k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type DeploymentWrapper struct {
@@ -21,13 +21,13 @@ type Deployment struct {
 
 	Replicas       *int32              `json:"replicas,omitempty"`
 	Recreate       bool                `json:"recreate,omitempty"`
-	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
-	MaxSurge       *intstr.IntOrString `json:"maxSurge,omitempty"`
+	MaxUnavailable *intstr.IntOrString `json:"max_unavailable,omitempty"`
+	MaxSurge       *intstr.IntOrString `json:"max_extra,omitempty"`
 
-	MinReadySeconds         int32  `json:"minReadySeconds,omitempty"`
-	RevisionHistoryLimit    *int32 `json:"revisionHistoryLimit,omitempty"`
+	MinReadySeconds         int32  `json:"min_ready,omitempty"`
+	RevisionHistoryLimit    *int32 `json:"max_revs,omitempty"`
 	Paused                  bool   `json:"paused,omitempty"`
-	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty"`
+	ProgressDeadlineSeconds *int32 `json:"progress_deadline,omitempty"`
 
 	Status *apps.DeploymentStatus `json:"status,omitempty"`
 

--- a/types/replicaset.go
+++ b/types/replicaset.go
@@ -1,11 +1,16 @@
 package types
 
 import (
+	"encoding/json"
+	"reflect"
+
+	"k8s.io/api/core/v1"
 	apps "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ReplicaSetWrapper struct {
-	ReplicaSet ReplicaSet `json:"replicaSet"`
+	ReplicaSet ReplicaSet `json:"replica_set"`
 }
 
 type ReplicaSet struct {
@@ -17,9 +22,170 @@ type ReplicaSet struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	Replicas        *int32 `json:"replicas,omitempty"`
-	MinReadySeconds int32  `json:"minReadySeconds,omitempty"`
-	PodSelector     string `json:"podSelector,omitempty"`
-	Template        *Pod   `json:"template,omitempty"`
+	MinReadySeconds int32  `json:"ready_seconds,omitempty"`
 
 	Status *apps.ReplicaSetStatus `json:"status,omitempty"`
+
+	// Selector in ReplicaSet can express more complex rules than just matching
+	// pod labels, so it needs its own field (unlike in ReplicationController).
+	// Leaving it blank has the same effect as omitting Selector in RC.
+	Selector *RSSelector `json:"selector,omitempty"`
+
+	// Template fields
+	TemplateMetadata       *RSTemplateMetadata `json:"pod_meta,omitempty"`
+	Volumes                []v1.Volume         `json:"volumes,omitempty"`
+	Affinity               []Affinity          `json:"affinity,omitempty"`
+	Containers             []Container         `json:"containers,omitempty"`
+	InitContainers         []Container         `json:"init_containers,omitempty"`
+	DNSPolicy              DNSPolicy           `json:"dns_policy,omitempty"`
+	HostAliases            []string            `json:"host_aliases,omitempty"`
+	HostMode               []HostMode          `json:"host_mode,omitempty"`
+	Hostname               string              `json:"hostname,omitempty"`
+	Registries             []string            `json:"registry_secrets,omitempty"`
+	RestartPolicy          RestartPolicy       `json:"restart_policy,omitempty"`
+	SchedulerName          string              `json:"scheduler_name,omitempty"`
+	Account                string              `json:"account,omitempty"`
+	Tolerations            []Toleration        `json:"tolerations,omitempty"`
+	TerminationGracePeriod *int64              `json:"termination_grace_period,omitempty"`
+	ActiveDeadline         *int64              `json:"active_deadline,omitempty"`
+	Node                   string              `json:"node,omitempty"`
+	Priority               *Priority           `json:"priority,omitempty"`
+	Conditions             []PodCondition      `json:"condition,omitempty"`
+	NodeIP                 string              `json:"node_ip,omitempty"`
+	StartTime              *metav1.Time        `json:"start_time,omitempty"`
+	Msg                    string              `json:"msg,omitempty"`
+	Phase                  PodPhase            `json:"phase,omitempty"`
+	IP                     string              `json:"ip,omitempty"`
+	QOS                    PodQOSClass         `json:"qos,omitempty"`
+	Reason                 string              `json:"reason,omitempty"`
+	FSGID                  *int64              `json:"fs_gid,omitempty"`
+	GIDs                   []int64             `json:"gids,omitempty"`
+}
+
+type RSTemplateMetadata struct {
+	Cluster     string            `json:"cluster,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type RSSelector struct {
+	Shorthand string
+	Labels    map[string]string
+}
+
+func RSTemplateMetadataFromPod(pod *Pod) *RSTemplateMetadata {
+	meta := RSTemplateMetadata{}
+	meta.Cluster = pod.Cluster
+	meta.Name = pod.Name
+	meta.Namespace = pod.Namespace
+	meta.Labels = pod.Labels
+	meta.Annotations = pod.Annotations
+
+	if reflect.DeepEqual(meta, RSTemplateMetadata{}) {
+		return nil
+	}
+
+	return &meta
+}
+
+func (rs *ReplicaSet) SetTemplate(pod *Pod) {
+	rs.TemplateMetadata = RSTemplateMetadataFromPod(pod)
+	rs.Volumes = pod.Volumes
+	rs.Affinity = pod.Affinity
+	rs.Containers = pod.Containers
+	rs.InitContainers = pod.InitContainers
+	rs.DNSPolicy = pod.DNSPolicy
+	rs.HostAliases = pod.HostAliases
+	rs.HostMode = pod.HostMode
+	rs.Hostname = pod.Hostname
+	rs.Registries = pod.Registries
+	rs.RestartPolicy = pod.RestartPolicy
+	rs.SchedulerName = pod.SchedulerName
+	rs.Account = pod.Account
+	rs.Tolerations = pod.Tolerations
+	rs.TerminationGracePeriod = pod.TerminationGracePeriod
+
+	rs.ActiveDeadline = pod.ActiveDeadline
+	rs.Node = pod.Node
+	rs.Priority = pod.Priority
+	rs.Conditions = pod.Conditions
+	rs.NodeIP = pod.NodeIP
+	rs.StartTime = pod.StartTime
+	rs.Msg = pod.Msg
+	rs.Phase = pod.Phase
+	rs.IP = pod.IP
+	rs.QOS = pod.QOS
+	rs.Reason = pod.Reason
+	rs.FSGID = pod.FSGID
+	rs.GIDs = pod.GIDs
+}
+
+func (rs *ReplicaSet) GetTemplate() *Pod {
+	pod := Pod{}
+
+	if rs.TemplateMetadata != nil {
+		pod.Cluster = rs.TemplateMetadata.Cluster
+		pod.Name = rs.TemplateMetadata.Name
+		pod.Namespace = rs.TemplateMetadata.Namespace
+		pod.Labels = rs.TemplateMetadata.Labels
+		pod.Annotations = rs.TemplateMetadata.Annotations
+	}
+
+	pod.Volumes = rs.Volumes
+	pod.Affinity = rs.Affinity
+	pod.Containers = rs.Containers
+	pod.InitContainers = rs.InitContainers
+	pod.DNSPolicy = rs.DNSPolicy
+	pod.HostAliases = rs.HostAliases
+	pod.HostMode = rs.HostMode
+	pod.Hostname = rs.Hostname
+	pod.Registries = rs.Registries
+	pod.RestartPolicy = rs.RestartPolicy
+	pod.SchedulerName = rs.SchedulerName
+	pod.Account = rs.Account
+	pod.Tolerations = rs.Tolerations
+	pod.TerminationGracePeriod = rs.TerminationGracePeriod
+
+	pod.ActiveDeadline = rs.ActiveDeadline
+	pod.Node = rs.Node
+	pod.Priority = rs.Priority
+	pod.Conditions = rs.Conditions
+	pod.NodeIP = rs.NodeIP
+	pod.StartTime = rs.StartTime
+	pod.Msg = rs.Msg
+	pod.Phase = rs.Phase
+	pod.IP = rs.IP
+	pod.QOS = rs.QOS
+	pod.Reason = rs.Reason
+	pod.FSGID = rs.FSGID
+	pod.GIDs = rs.GIDs
+
+	return &pod
+}
+
+func (s *RSSelector) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err == nil {
+		s.Shorthand = str
+		return nil
+	}
+
+	labels := map[string]string{}
+	err = json.Unmarshal(data, &labels)
+	if err == nil {
+		s.Labels = labels
+	}
+
+	return err
+}
+
+func (s RSSelector) MarshalJSON() ([]byte, error) {
+	if len(s.Shorthand) > 0 {
+		return json.Marshal(s.Shorthand)
+	}
+
+	return json.Marshal(s.Labels)
 }

--- a/types/replicationcontroller.go
+++ b/types/replicationcontroller.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"reflect"
+
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ReplicationControllerWrapper struct {
@@ -19,9 +22,139 @@ type ReplicationController struct {
 	Replicas        *int32 `json:"replicas,omitempty"`
 	MinReadySeconds int32  `json:"ready_seconds,omitempty"`
 
+	Status *v1.ReplicationControllerStatus `json:"status,omitempty"`
+
 	// Selector and the Template's Labels are expected to be equal
 	// if both exist, so we standardize on using the Template's labels.
-	Template *Pod `json:"template,omitempty"`
+	Selector map[string]string `json:"selector,omitempty"`
 
-	Status *v1.ReplicationControllerStatus `json:"status,omitempty"`
+	// Template fields
+	TemplateMetadata       *RCTemplateMetadata `json:"pod_meta,omitempty"`
+	Volumes                []v1.Volume         `json:"volumes,omitempty"`
+	Affinity               []Affinity          `json:"affinity,omitempty"`
+	Containers             []Container         `json:"containers,omitempty"`
+	InitContainers         []Container         `json:"init_containers,omitempty"`
+	DNSPolicy              DNSPolicy           `json:"dns_policy,omitempty"`
+	HostAliases            []string            `json:"host_aliases,omitempty"`
+	HostMode               []HostMode          `json:"host_mode,omitempty"`
+	Hostname               string              `json:"hostname,omitempty"`
+	Registries             []string            `json:"registry_secrets,omitempty"`
+	RestartPolicy          RestartPolicy       `json:"restart_policy,omitempty"`
+	SchedulerName          string              `json:"scheduler_name,omitempty"`
+	Account                string              `json:"account,omitempty"`
+	Tolerations            []Toleration        `json:"tolerations,omitempty"`
+	TerminationGracePeriod *int64              `json:"termination_grace_period,omitempty"`
+	ActiveDeadline         *int64              `json:"active_deadline,omitempty"`
+	Node                   string              `json:"node,omitempty"`
+	Priority               *Priority           `json:"priority,omitempty"`
+	Conditions             []PodCondition      `json:"condition,omitempty"`
+	NodeIP                 string              `json:"node_ip,omitempty"`
+	StartTime              *metav1.Time        `json:"start_time,omitempty"`
+	Msg                    string              `json:"msg,omitempty"`
+	Phase                  PodPhase            `json:"phase,omitempty"`
+	IP                     string              `json:"ip,omitempty"`
+	QOS                    PodQOSClass         `json:"qos,omitempty"`
+	Reason                 string              `json:"reason,omitempty"`
+	FSGID                  *int64              `json:"fs_gid,omitempty"`
+	GIDs                   []int64             `json:"gids,omitempty"`
+}
+
+type RCTemplateMetadata struct {
+	Cluster     string            `json:"cluster,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+func RCTemplateMetadataFromPod(pod *Pod) *RCTemplateMetadata {
+	meta := RCTemplateMetadata{}
+	meta.Cluster = pod.Cluster
+	meta.Name = pod.Name
+	meta.Namespace = pod.Namespace
+	meta.Annotations = pod.Annotations
+
+	if reflect.DeepEqual(meta, RCTemplateMetadata{}) {
+		return nil
+	}
+
+	return &meta
+}
+
+func (rc *ReplicationController) SetTemplate(pod *Pod) {
+	rc.TemplateMetadata = RCTemplateMetadataFromPod(pod)
+
+	rc.Selector = pod.Labels
+
+	rc.Volumes = pod.Volumes
+	rc.Affinity = pod.Affinity
+	rc.Containers = pod.Containers
+	rc.InitContainers = pod.InitContainers
+	rc.DNSPolicy = pod.DNSPolicy
+	rc.HostAliases = pod.HostAliases
+	rc.HostMode = pod.HostMode
+	rc.Hostname = pod.Hostname
+	rc.Registries = pod.Registries
+	rc.RestartPolicy = pod.RestartPolicy
+	rc.SchedulerName = pod.SchedulerName
+	rc.Account = pod.Account
+	rc.Tolerations = pod.Tolerations
+	rc.TerminationGracePeriod = pod.TerminationGracePeriod
+
+	rc.ActiveDeadline = pod.ActiveDeadline
+	rc.Node = pod.Node
+	rc.Priority = pod.Priority
+	rc.Conditions = pod.Conditions
+	rc.NodeIP = pod.NodeIP
+	rc.StartTime = pod.StartTime
+	rc.Msg = pod.Msg
+	rc.Phase = pod.Phase
+	rc.IP = pod.IP
+	rc.QOS = pod.QOS
+	rc.Reason = pod.Reason
+	rc.FSGID = pod.FSGID
+	rc.GIDs = pod.GIDs
+}
+
+func (rc *ReplicationController) GetTemplate() *Pod {
+	pod := Pod{}
+
+	if rc.TemplateMetadata != nil {
+		pod.Cluster = rc.TemplateMetadata.Cluster
+		pod.Name = rc.TemplateMetadata.Name
+		pod.Namespace = rc.TemplateMetadata.Namespace
+		pod.Annotations = rc.TemplateMetadata.Annotations
+	}
+
+	pod.Labels = rc.Selector
+
+	pod.Volumes = rc.Volumes
+	pod.Affinity = rc.Affinity
+	pod.Containers = rc.Containers
+	pod.InitContainers = rc.InitContainers
+	pod.DNSPolicy = rc.DNSPolicy
+	pod.HostAliases = rc.HostAliases
+	pod.HostMode = rc.HostMode
+	pod.Hostname = rc.Hostname
+	pod.Registries = rc.Registries
+	pod.RestartPolicy = rc.RestartPolicy
+	pod.SchedulerName = rc.SchedulerName
+	pod.Account = rc.Account
+	pod.Tolerations = rc.Tolerations
+	pod.TerminationGracePeriod = rc.TerminationGracePeriod
+
+	pod.ActiveDeadline = rc.ActiveDeadline
+	pod.Node = rc.Node
+	pod.Priority = rc.Priority
+	pod.Conditions = rc.Conditions
+	pod.NodeIP = rc.NodeIP
+	pod.StartTime = rc.StartTime
+	pod.Msg = rc.Msg
+	pod.Phase = rc.Phase
+	pod.IP = rc.IP
+	pod.QOS = rc.QOS
+	pod.Reason = rc.Reason
+	pod.FSGID = rc.FSGID
+	pod.GIDs = rc.GIDs
+
+	return &pod
 }

--- a/types/replicationcontroller.go
+++ b/types/replicationcontroller.go
@@ -5,7 +5,7 @@ import (
 )
 
 type ReplicationControllerWrapper struct {
-	ReplicationController ReplicationController `json:"replicationController"`
+	ReplicationController ReplicationController `json:"replication_controller"`
 }
 
 type ReplicationController struct {
@@ -16,10 +16,12 @@ type ReplicationController struct {
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	Replicas        *int32            `json:"replicas,omitempty"`
-	MinReadySeconds int32             `json:"minReadySeconds,omitempty"`
-	PodLabels       map[string]string `json:"podLabels,omitempty"`
-	Template        *Pod              `json:"template,omitempty"`
+	Replicas        *int32 `json:"replicas,omitempty"`
+	MinReadySeconds int32  `json:"ready_seconds,omitempty"`
+
+	// Selector and the Template's Labels are expected to be equal
+	// if both exist, so we standardize on using the Template's labels.
+	Template *Pod `json:"template,omitempty"`
 
 	Status *v1.ReplicationControllerStatus `json:"status,omitempty"`
 }


### PR DESCRIPTION
#36, #40 

This is just flattening Template into the parent object and the field tweaks from those issues.
Also a small bugfix where errors from the "imports" feature weren't being exposed.

Still TODO: multiple versions of RS/Deployment.

@wlan0 