### PR TITLE
Service Type field because it can't always be inferred

### DIFF
--- a/converter/converters/koki_service_to_kube_v1_service_test.go
+++ b/converter/converters/koki_service_to_kube_v1_service_test.go
@@ -43,6 +43,7 @@ var s1 = &types.ServiceWrapper{
 		Selector: map[string]string{
 			"labelKey": "labelValue",
 		},
+		Type:             types.ClusterIPServiceTypeDefault,
 		ExternalIPs:      []types.IPAddr{types.IPAddr("1.1.1.1")},
 		Port:             &httpServicePort,
 		ClusterIP:        types.ClusterIPAddr(types.IPAddr("1.1.1.10")),
@@ -56,6 +57,7 @@ var s2 = &types.ServiceWrapper{
 		Selector: map[string]string{
 			"labelKey": "labelValue",
 		},
+		Type:        types.ClusterIPServiceTypeNodePort,
 		ExternalIPs: []types.IPAddr{types.IPAddr("1.1.1.1")},
 		Ports: []types.NamedServicePort{
 			httpNamedServicePort,
@@ -71,6 +73,7 @@ var s3 = &types.ServiceWrapper{
 		Selector: map[string]string{
 			"labelKey": "labelValue",
 		},
+		Type:        types.ClusterIPServiceTypeLoadBalancer,
 		ExternalIPs: []types.IPAddr{types.IPAddr("1.1.1.1")},
 		Ports: []types.NamedServicePort{
 			httpNamedServicePort,

--- a/converter/converters/kube_v1_service_to_koki.go
+++ b/converter/converters/kube_v1_service_to_koki.go
@@ -29,6 +29,11 @@ func Convert_Kube_v1_Service_to_Koki_Service(kubeService *v1.Service) (*types.Se
 		return kokiWrapper, nil
 	}
 
+	kokiService.Type, err = convertServiceType(kubeService.Spec.Type)
+	if err != nil {
+		return nil, err
+	}
+
 	kokiService.Selector = kubeService.Spec.Selector
 	kokiService.ClusterIP = types.ClusterIP(kubeService.Spec.ClusterIP)
 	kokiService.ExternalIPs = convertExternalIPs(kubeService.Spec.ExternalIPs)
@@ -57,6 +62,23 @@ func Convert_Kube_v1_Service_to_Koki_Service(kubeService *v1.Service) (*types.Se
 	}
 
 	return kokiWrapper, nil
+}
+
+func convertServiceType(kubeType v1.ServiceType) (types.ClusterIPServiceType, error) {
+	if len(kubeType) == 0 {
+		return "", nil
+	}
+
+	switch kubeType {
+	case v1.ServiceTypeClusterIP:
+		return types.ClusterIPServiceTypeDefault, nil
+	case v1.ServiceTypeNodePort:
+		return types.ClusterIPServiceTypeNodePort, nil
+	case v1.ServiceTypeLoadBalancer:
+		return types.ClusterIPServiceTypeLoadBalancer, nil
+	default:
+		return "", util.InvalidInstanceError(kubeType)
+	}
 }
 
 func convertIngress(kubeIngress []v1.LoadBalancerIngress) ([]types.Ingress, error) {

--- a/examples/service/example2.short.yaml
+++ b/examples/service/example2.short.yaml
@@ -6,5 +6,6 @@ service:
   port: 80:8080
   selector:
     labelKey: labelValue
+  type: cluster-ip
   stickiness: true
   version: v1

--- a/examples/service/example3.short.yaml
+++ b/examples/service/example3.short.yaml
@@ -9,4 +9,5 @@ service:
   selector:
     labelKey: labelValue
   stickiness: true
+  type: node-port
   version: v1

--- a/examples/service/example4.short.yaml
+++ b/examples/service/example4.short.yaml
@@ -15,4 +15,5 @@ service:
   route_policy: node-local
   selector:
     labelKey: labelValue
+  type: load-balancer
   version: v1

--- a/examples/service/example5.short.yaml
+++ b/examples/service/example5.short.yaml
@@ -9,4 +9,5 @@ service:
   selector:
     labelKey: labelValue
   stickiness: true
+  type: node-port
   version: v1


### PR DESCRIPTION
#60 
@wlan0 

I'm only doing `Type` for ClusterIP/NodePort/LB because ExternalName is very easy to infer.