### PR TITLE
make sure errors come with sufficient context

### DIFF
--- a/converter/converter.go
+++ b/converter/converter.go
@@ -1,8 +1,6 @@
 package converter
 
 import (
-	unstructuredconversion "k8s.io/apimachinery/pkg/conversion/unstructured"
-
 	"github.com/koki/short/parser"
 )
 
@@ -31,10 +29,6 @@ func ConvertToKokiNative(objs []map[string]interface{}) ([]interface{}, error) {
 		obj := objs[i]
 		typedObj, err := parser.ParseSingleKubeNative(obj)
 		if err != nil {
-			return nil, err
-		}
-
-		if err := unstructuredconversion.DefaultConverter.FromUnstructured(obj, typedObj); err != nil {
 			return nil, err
 		}
 

--- a/converter/converters/koki_deployment_to_kube_deployment.go
+++ b/converter/converters/koki_deployment_to_kube_deployment.go
@@ -25,7 +25,7 @@ func Convert_Koki_Deployment_to_Kube_Deployment(deployment *types.DeploymentWrap
 	// Serialize the "generic" kube Deployment.
 	b, err := yaml.Marshal(kubeDeployment)
 	if err != nil {
-		return nil, err
+		return nil, util.InvalidValueErrorf(kubeDeployment, "couldn't serialize 'generic' kube Deployment: %s", err.Error())
 	}
 
 	// Deserialize a versioned kube Deployment using its apiVersion.
@@ -50,6 +50,8 @@ func Convert_Koki_Deployment_to_Kube_Deployment(deployment *types.DeploymentWrap
 		}
 	case *exts.Deployment:
 		// Perform exts/v1beta1-specific initialization here.
+	default:
+		return nil, util.TypeErrorf(versionedDeployment, "deserialized the manifest, but not as a supported kube Deployment")
 	}
 
 	return versionedDeployment, nil

--- a/converter/converters/koki_pod_to_kube_v1_pod.go
+++ b/converter/converters/koki_pod_to_kube_v1_pod.go
@@ -479,12 +479,12 @@ func revertHostAliases(aliases []string) ([]v1.HostAlias, error) {
 			hostNames := strings.Split(strings.TrimSpace(fields[1]), " ")
 			for i := range hostNames {
 				hostname := hostNames[i]
-				if hostname != "" || hostname != " " {
+				if hostname != "" && hostname != " " {
 					hostAlias.Hostnames = append(hostAlias.Hostnames, hostname)
 				}
 			}
 		} else {
-			return nil, util.InvalidInstanceError(alias)
+			return nil, util.InvalidValueForTypeErrorf(alias, hostAlias, "expected 2 space-separated values")
 		}
 		hostAliases = append(hostAliases, hostAlias)
 	}
@@ -679,7 +679,7 @@ func revertLifecycleAction(action *types.Action) (*v1.Handler, error) {
 	if action.Net != nil {
 		urlStruct, err := url.Parse(action.Net.URL)
 		if err != nil {
-			return nil, err
+			return nil, util.InvalidInstanceErrorf(action, "couldn't parse URL: %s", err)
 		}
 		var host string
 		var port intstr.IntOrString
@@ -823,7 +823,7 @@ func revertProbe(probe *types.Probe) (*v1.Probe, error) {
 	if probe.Net != nil {
 		urlStruct, err := url.Parse(probe.Net.URL)
 		if err != nil {
-			return nil, err
+			return nil, util.InvalidInstanceErrorf(probe, "couldn't parse URL: %s", err.Error())
 		}
 		if urlStruct.Scheme == "TCP" {
 			hostPort := urlStruct.Host
@@ -907,7 +907,7 @@ func revertResources(cpu *types.CPU, mem *types.Mem) (v1.ResourceRequirements, e
 		if cpu.Min != "" {
 			q, err := resource.ParseQuantity(cpu.Min)
 			if err != nil {
-				return requirements, err
+				return requirements, util.InvalidInstanceErrorf(cpu, "couldn't parse min quantity: %s", err)
 			}
 			requests[v1.ResourceCPU] = q
 		}
@@ -915,7 +915,7 @@ func revertResources(cpu *types.CPU, mem *types.Mem) (v1.ResourceRequirements, e
 		if cpu.Max != "" {
 			q, err := resource.ParseQuantity(cpu.Max)
 			if err != nil {
-				return requirements, err
+				return requirements, util.InvalidInstanceErrorf(cpu, "couldn't parse max quantity: %s", err)
 			}
 			limits[v1.ResourceCPU] = q
 		}
@@ -925,7 +925,7 @@ func revertResources(cpu *types.CPU, mem *types.Mem) (v1.ResourceRequirements, e
 		if mem.Min != "" {
 			q, err := resource.ParseQuantity(mem.Min)
 			if err != nil {
-				return requirements, err
+				return requirements, util.InvalidInstanceErrorf(mem, "couldn't parse min quantity: %s", err)
 			}
 			requests[v1.ResourceMemory] = q
 		}
@@ -933,7 +933,7 @@ func revertResources(cpu *types.CPU, mem *types.Mem) (v1.ResourceRequirements, e
 		if mem.Max != "" {
 			q, err := resource.ParseQuantity(mem.Max)
 			if err != nil {
-				return requirements, err
+				return requirements, util.InvalidInstanceErrorf(mem, "couldn't parse max quantity: %s", err)
 			}
 			limits[v1.ResourceMemory] = q
 		}
@@ -1004,7 +1004,7 @@ func revertEnv(envs []types.Env) ([]v1.EnvVar, []v1.EnvFromSource, error) {
 				}
 				envsFromSource = append(envsFromSource, envVarFromSrc)
 			} else {
-				return nil, nil, util.InvalidInstanceError(e)
+				return nil, nil, util.InvalidInstanceErrorf(e, "expected either one or two colon-separated values after 'config:'")
 			}
 			continue
 		}
@@ -1039,7 +1039,7 @@ func revertEnv(envs []types.Env) ([]v1.EnvVar, []v1.EnvFromSource, error) {
 				}
 				envsFromSource = append(envsFromSource, envVarFromSrc)
 			} else {
-				return nil, nil, util.InvalidInstanceError(e)
+				return nil, nil, util.InvalidInstanceErrorf(e, "expected either one or two colon-separated values after 'secret:'")
 			}
 			continue
 		}

--- a/converter/converters/koki_replicaset_to_kube_replicaset.go
+++ b/converter/converters/koki_replicaset_to_kube_replicaset.go
@@ -25,7 +25,7 @@ func Convert_Koki_ReplicaSet_to_Kube_ReplicaSet(rs *types.ReplicaSetWrapper) (in
 	// Serialize the "generic" kube ReplicaSet.
 	b, err := yaml.Marshal(kubeRS)
 	if err != nil {
-		return nil, err
+		return nil, util.InvalidValueErrorf(kubeRS, "couldn't serialize 'generic' kube ReplicaSet: %s", err.Error())
 	}
 
 	// Deserialize a versioned kube ReplicaSet using its apiVersion.
@@ -111,7 +111,7 @@ func revertRSSelector(name string, selector *types.RSSelector, templateLabels ma
 	if len(selector.Shorthand) > 0 {
 		labelSelector, err := expressions.ParseLabelSelector(selector.Shorthand)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, util.InvalidInstanceErrorf(selector, "%s", err)
 		}
 		if len(templateLabels) == 0 && len(labelSelector.MatchExpressions) == 0 {
 			// Selector is only Labels, and Template.Labels is empty.

--- a/converter/converters/koki_service_to_kube_v1_service.go
+++ b/converter/converters/koki_service_to_kube_v1_service.go
@@ -36,10 +36,6 @@ func Convert_Koki_Service_To_Kube_v1_Service(service *types.ServiceWrapper) (*v1
 	kubeService.Spec.ClusterIP = string(kokiService.ClusterIP)
 	kubeService.Spec.ExternalIPs = revertExternalIPs(kokiService.ExternalIPs)
 	kubeService.Spec.SessionAffinity, kubeService.Spec.SessionAffinityConfig = revertSessionAffinity(kokiService.ClientIPAffinity)
-	if err != nil {
-		return nil, err
-	}
-
 	kubeService.Spec.PublishNotReadyAddresses = kokiService.PublishNotReadyAddresses
 
 	kubeService.Spec.ExternalTrafficPolicy, err = revertExternalTrafficPolicy(kokiService.ExternalTrafficPolicy)

--- a/converter/converters/kube_deployment_to_koki_deployment.go
+++ b/converter/converters/kube_deployment_to_koki_deployment.go
@@ -24,13 +24,13 @@ func Convert_Kube_Deployment_to_Koki_Deployment(kubeDeployment runtime.Object) (
 	// Serialize as v1beta2
 	b, err := yaml.Marshal(kubeDeployment)
 	if err != nil {
-		return nil, err
+		return nil, util.InvalidInstanceErrorf(kubeDeployment, "couldn't serialize kube Deployment after setting apiVersion to apps/v1beta2: %s", err.Error())
 	}
 
 	// Deserialize the "generic" kube Deployment
 	genericDeployment, err := parser.ParseSingleKubeNativeFromBytes(b)
 	if err != nil {
-		return nil, err
+		return nil, util.InvalidInstanceErrorf(string(b), "couldn't deserialize 'generic' kube Deployment: %s", err.Error())
 	}
 
 	if genericDeployment, ok := genericDeployment.(*appsv1beta2.Deployment); ok {
@@ -48,7 +48,7 @@ func Convert_Kube_Deployment_to_Koki_Deployment(kubeDeployment runtime.Object) (
 		return kokiWrapper, nil
 	}
 
-	return nil, util.InvalidInstanceErrorf(genericDeployment, "couldn't reserialize as apps/v1beta2.Deployment")
+	return nil, util.InvalidInstanceErrorf(genericDeployment, "didn't deserialize 'generic' kube Deployment as apps/v1beta2.Deployment")
 }
 
 func Convert_Kube_v1beta2_Deployment_to_Koki_Deployment(kubeDeployment *appsv1beta2.Deployment) (*types.DeploymentWrapper, error) {

--- a/converter/converters/kube_replicaset_to_koki_replicaset.go
+++ b/converter/converters/kube_replicaset_to_koki_replicaset.go
@@ -26,13 +26,13 @@ func Convert_Kube_ReplicaSet_to_Koki_ReplicaSet(kubeRS runtime.Object) (*types.R
 	// Serialize as v1beta2
 	b, err := yaml.Marshal(kubeRS)
 	if err != nil {
-		return nil, err
+		return nil, util.InvalidInstanceErrorf(kubeRS, "couldn't serialize kube ReplicaSet after setting apiVersion to apps/v1beta2: %s", err.Error())
 	}
 
 	// Deserialize the "generic" kube ReplicaSet
 	genericReplicaSet, err := parser.ParseSingleKubeNativeFromBytes(b)
 	if err != nil {
-		return nil, err
+		return nil, util.InvalidValueErrorf(string(b), "couldn't deserialize 'generic' kube ReplicaSet: %s", err.Error())
 	}
 
 	if genericReplicaSet, ok := genericReplicaSet.(*appsv1beta2.ReplicaSet); ok {
@@ -50,7 +50,7 @@ func Convert_Kube_ReplicaSet_to_Koki_ReplicaSet(kubeRS runtime.Object) (*types.R
 		return kokiWrapper, nil
 	}
 
-	return nil, util.InvalidInstanceErrorf(genericReplicaSet, "couldn't reserialize as apps/v1beta2.ReplicaSet")
+	return nil, util.InvalidInstanceErrorf(genericReplicaSet, "didn't deserialize 'generic' ReplicaSet as apps/v1beta2.ReplicaSet")
 }
 
 func Convert_Kube_v1beta2_ReplicaSet_to_Koki_ReplicaSet(kubeRS *appsv1beta2.ReplicaSet) (*types.ReplicaSetWrapper, error) {

--- a/converter/converters/kube_v1_pod_to_koki.go
+++ b/converter/converters/kube_v1_pod_to_koki.go
@@ -672,7 +672,7 @@ func convertNodeAffinity(nodeAffinity *v1.NodeAffinity) ([]types.Affinity, error
 				value := strings.Join(expr.Values, ",")
 				op, err := convertOperator(expr.Operator)
 				if err != nil {
-					return nil, err
+					return nil, util.InvalidInstanceErrorf(nodeHardAffinity, "unsupported Operator: %s", err.Error())
 				}
 				kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
 				if expr.Operator == v1.NodeSelectorOpExists {
@@ -705,7 +705,7 @@ func convertNodeAffinity(nodeAffinity *v1.NodeAffinity) ([]types.Affinity, error
 				value := strings.Join(expr.Values, ",")
 				op, err := convertOperator(expr.Operator)
 				if err != nil {
-					return nil, err
+					return nil, util.InvalidInstanceErrorf(nodeSoftAffinity, "unsupported Operator: %s", err.Error())
 				}
 				kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
 				if expr.Operator == v1.NodeSelectorOpExists {
@@ -792,7 +792,7 @@ func convertPodWeightedAffinityTerms(prefix string, podSoftAffinity []v1.Weighte
 				value := strings.Join(expr.Values, ",")
 				op, err := expressions.ConvertOperatorLabelSelector(expr.Operator)
 				if err != nil {
-					return nil, err
+					return nil, util.InvalidInstanceErrorf(selectorTerm.PodAffinityTerm, "unsupported Operator: %s", err.Error())
 				}
 				kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
 				if expr.Operator == metav1.LabelSelectorOpExists {
@@ -852,7 +852,7 @@ func convertPodAffinityTerms(prefix string, podHardAffinity []v1.PodAffinityTerm
 				value := strings.Join(expr.Values, ",")
 				op, err := expressions.ConvertOperatorLabelSelector(expr.Operator)
 				if err != nil {
-					return nil, err
+					return nil, util.InvalidInstanceErrorf(selectorTerm, "unsupported Operator: %s", err.Error())
 				}
 				kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
 				if expr.Operator == metav1.LabelSelectorOpExists {
@@ -1004,7 +1004,7 @@ func convertTolerations(tolerations []v1.Toleration) ([]types.Toleration, error)
 		} else if toleration.Operator == v1.TolerationOpExists {
 			tolExpr = fmt.Sprintf("%s", toleration.Key)
 		} else {
-			return nil, util.InvalidInstanceError(toleration.Operator)
+			return nil, util.InvalidInstanceErrorf(toleration, "unsupported operator")
 		}
 		if tolExpr != "" {
 			if toleration.Effect != "" {

--- a/converter/koki_converter.go
+++ b/converter/koki_converter.go
@@ -29,7 +29,7 @@ func DetectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
 	case *types.VolumeWrapper:
 		return &kokiObj.Volume, nil
 	default:
-		return nil, util.TypeError(kokiObj)
+		return nil, util.TypeErrorf(kokiObj, "can't convert from unsupported koki type")
 	}
 }
 
@@ -55,6 +55,6 @@ func DetectAndConvertFromKubeObj(kubeObj runtime.Object) (interface{}, error) {
 		return converters.Convert_Kube_v1_Service_to_Koki_Service(kubeObj)
 
 	default:
-		return nil, util.TypeError(kubeObj)
+		return nil, util.TypeErrorf(kubeObj, "can't convert from unsupported kube type")
 	}
 }

--- a/parser/expressions/labelselector.go
+++ b/parser/expressions/labelselector.go
@@ -22,7 +22,7 @@ func ParseLabelSelector(s string) (*metav1.LabelSelector, error) {
 	for _, seg := range segs {
 		expr, err := ParseExpr(seg, []string{"!=", "="})
 		if err != nil {
-			return nil, err
+			return nil, util.InvalidValueForTypeErrorf(s, metav1.LabelSelector{}, "couldn't parse subexpression: %s", err.Error())
 		}
 
 		if expr == nil {
@@ -98,7 +98,7 @@ func UnparseLabelSelector(kubeSelector *metav1.LabelSelector) (string, error) {
 		value := strings.Join(expr.Values, ",")
 		op, err := ConvertOperatorLabelSelector(expr.Operator)
 		if err != nil {
-			return "", err
+			return "", util.InvalidInstanceErrorf(expr, "invalid operator: %s", err.Error())
 		}
 		kokiExpr := fmt.Sprintf("%s%s%s", expr.Key, op, value)
 		if expr.Operator == metav1.LabelSelectorOpExists {

--- a/parser/files.go
+++ b/parser/files.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -10,12 +11,11 @@ import (
 func openStreamsFromFiles(filenames []string) ([]io.ReadCloser, error) {
 	readers := []io.ReadCloser{}
 
-	for i := range filenames {
-		name := filenames[i]
+	for _, name := range filenames {
 		glog.V(5).Infof("opening file %s for reading", name)
 		f, err := os.Open(name)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed opening file (%s): %s", name, err.Error())
 		}
 
 		readers = append(readers, f)

--- a/parser/kube.go
+++ b/parser/kube.go
@@ -6,6 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/ghodss/yaml"
+
+	"github.com/koki/short/util"
 )
 
 func ParseSingleKubeNativeFromBytes(data []byte) (runtime.Object, error) {
@@ -25,12 +27,12 @@ func ParseSingleKubeNative(obj map[string]interface{}) (runtime.Object, error) {
 
 	typedObj, err := creator.New(u.GetObjectKind().GroupVersionKind())
 	if err != nil {
-		return nil, err
+		return nil, util.InvalidValueErrorf(u, "unsupported GroupVersionKind: %s", err.Error())
 	}
 
 	if err := unstructuredconversion.DefaultConverter.FromUnstructured(obj, typedObj); err != nil {
-		return nil, err
+		return nil, util.InvalidValueForTypeErrorf(obj, typedObj, "couldn't convert to typed kube obj: %s", err.Error())
 	}
 
-	return typedObj, err
+	return typedObj, nil
 }

--- a/parser/kube.go
+++ b/parser/kube.go
@@ -27,7 +27,7 @@ func ParseSingleKubeNative(obj map[string]interface{}) (runtime.Object, error) {
 
 	typedObj, err := creator.New(u.GetObjectKind().GroupVersionKind())
 	if err != nil {
-		return nil, util.InvalidValueErrorf(u, "unsupported GroupVersionKind: %s", err.Error())
+		return nil, util.InvalidValueErrorf(u, "unsupported apiVersion/kind (is the manifest kube-native format?): %s", err.Error())
 	}
 
 	if err := unstructuredconversion.DefaultConverter.FromUnstructured(obj, typedObj); err != nil {

--- a/types/env.go
+++ b/types/env.go
@@ -101,12 +101,20 @@ func (e *Env) UnmarshalJSON(value []byte) error {
 
 // MarshalJSON implements the json.Marshaller interface.
 func (e Env) MarshalJSON() ([]byte, error) {
+	var b []byte
+	var err error
 	switch e.Type {
 	case EnvValType:
-		return json.Marshal(UnparseEnvVal(*e.Val))
+		b, err = json.Marshal(UnparseEnvVal(*e.Val))
 	case EnvFromType:
-		return json.Marshal(e.From)
+		b, err = json.Marshal(e.From)
 	default:
 		return []byte{}, util.InvalidInstanceError(e.Type)
 	}
+
+	if err != nil {
+		return nil, util.InvalidInstanceErrorf(e, "couldn't marshal to JSON: %s", err.Error())
+	}
+
+	return b, nil
 }

--- a/types/pull_policy.go
+++ b/types/pull_policy.go
@@ -1,1 +1,0 @@
-package types

--- a/types/service.go
+++ b/types/service.go
@@ -119,7 +119,13 @@ func (i Ingress) String() string {
 }
 
 func (i Ingress) MarshalJSON() ([]byte, error) {
-	return json.Marshal(i.String())
+	str := i.String()
+	b, err := json.Marshal(str)
+	if err != nil {
+		return nil, util.InvalidInstanceErrorf(i, "couldn't marshal from string (%s) to JSON: %s", str, err.Error())
+	}
+
+	return b, nil
 }
 
 func (s *Service) SetLoadBalancer(lb *LoadBalancer) {

--- a/util/util.go
+++ b/util/util.go
@@ -9,6 +9,12 @@ import (
 	"github.com/kr/pretty"
 )
 
+var verboseErrors = false
+
+func SetVerboseErrors(verbose bool) {
+	verboseErrors = verbose
+}
+
 func ExitWithErr(msg interface{}) {
 	glog.Error(msg)
 	os.Exit(1)
@@ -42,17 +48,29 @@ func InvalidInstanceErrorf(obj interface{}, msgFormat string, args ...interface{
 // InvalidValueErrorf is used when the type isn't meaningful--just the contents and the
 // context matter.
 func InvalidValueErrorf(val interface{}, msgFormat string, args ...interface{}) error {
-	return pretty.Errorf("%s\n%# v", pretty.Sprintf(msgFormat, args...), val)
+	if verboseErrors {
+		return pretty.Errorf("%s\n(%# v)", pretty.Sprintf(msgFormat, args...), val)
+	}
+
+	return pretty.Errorf("(%s) value: %s", reflect.TypeOf(val), pretty.Sprintf(msgFormat, args...))
 }
 
 // InvalidValueForTypeErrorf is used when the type isn't meaningful--just the contents and the
 // context matter.
 func InvalidValueForTypeErrorf(val, typedObj interface{}, msgFormat string, args ...interface{}) error {
-	return pretty.Errorf("for type (%s), unrecognized value\n%s\n%# v", reflect.TypeOf(typedObj), pretty.Sprintf(msgFormat, args...), val)
+	if verboseErrors {
+		return pretty.Errorf("for type (%s), unrecognized value\n%s\n%# v", reflect.TypeOf(typedObj), pretty.Sprintf(msgFormat, args...), val)
+	}
+
+	return pretty.Errorf("for type (%s), unrecognized (%s) value: %s", reflect.TypeOf(typedObj), reflect.TypeOf(val), pretty.Sprintf(msgFormat, args...))
 }
 
 func instanceError(obj interface{}, msg string) error {
-	return pretty.Errorf("%s: %s\n(%# v)", reflect.TypeOf(obj), msg, obj)
+	if verboseErrors {
+		return pretty.Errorf("%s: %s\n(%# v)", reflect.TypeOf(obj), msg, obj)
+	}
+
+	return pretty.Errorf("%s: %s", reflect.TypeOf(obj), msg)
 }
 
 func errorf(addedMsg, f interface{}, args ...interface{}) error {


### PR DESCRIPTION
added a flag --verbose-errors to indicate that error messages should include pretty-printed object contents instead of just their types (default).

for workflows that skip the import feature, also added filename to error messages. (since imports will be redesigned anyway)

@wlan0 
