### PR TITLE
version cmd says koki/short, includes latest tag

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,7 +13,7 @@ var (
 		Use:   "version",
 		Short: "Prints the version of short",
 		Run: func(*cobra.Command, []string) {
-			fmt.Printf("koki/shorthand: %s\n", GITCOMMIT)
+			fmt.Printf("koki/short: %s\n", GITCOMMIT)
 		},
 	}
 )

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -7,7 +7,7 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 COMMIT=$(git rev-parse --short HEAD)
-GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
+GIT_TAG=$(git describe --tags 2>/dev/null | head -n 1)
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG


### PR DESCRIPTION
#71 

`git describe --tags` shows tag + commit if commits were added after the latest tag.
`git tag -l --contains HEAD` only shows a tag if HEAD is tagged.

@wlan0 