### PR TITLE
multiple exported resources per module

### DIFF
--- a/examples/imports/affinity.yaml
+++ b/examples/imports/affinity.yaml
@@ -1,8 +1,10 @@
 params:
 - this_app: the app label for this app
 - colocate_with: the app label to colocate with
-affinity:
-- pod: app=${colocate_with}:soft
-  topology: kubernetes.io/hostname
-- anti_pod: app=${this_app}
-  topology: kubernetes.io/hostname
+exports:
+- default: some affinity rules
+  value:
+  - pod: app=${colocate_with}:soft
+    topology: kubernetes.io/hostname
+  - anti_pod: app=${this_app}
+    topology: kubernetes.io/hostname

--- a/examples/imports/app0.yaml
+++ b/examples/imports/app0.yaml
@@ -2,4 +2,10 @@ imports:
 - pod: ./pod0.yaml
   params:
     name: doot
-pod: ${pod}
+- some_deployment: ../deployment/example5.short.yaml
+exports:
+- app_pod: "the application's pod"
+  value: ${pod}
+- example_deployment: an example deployment
+  value: ${some_deployment}
+

--- a/examples/imports/bad-affinity.yaml
+++ b/examples/imports/bad-affinity.yaml
@@ -1,5 +1,10 @@
-affinity:
-- pod: app=frontend:soft:asdf
-  topology: kubernetes.io/hostname
-- anti_pod: app=backend
-  topology: kubernetes.io/hostname
+params:
+- this_app: the app label for this app
+- colocate_with: the app label to colocate with
+exports:
+- default: some affinity rules
+  value:
+  - pod: app=${colocate_with}:soft:asdf
+    topology: kubernetes.io/hostname
+  - anti_pod: app=${this_app}
+    topology: kubernetes.io/hostname

--- a/examples/imports/bad-app0.yaml
+++ b/examples/imports/bad-app0.yaml
@@ -1,0 +1,7 @@
+imports:
+- pod: ./bad-pod0.yaml
+  params:
+    name: doot
+exports:
+- default: "the application's pod"
+  value: ${pod}

--- a/examples/imports/bad-containers.yaml
+++ b/examples/imports/bad-containers.yaml
@@ -1,10 +1,14 @@
-containers:
-- name: busybox
-  expose: asdf
-  image: busybox:latest
-  tty: true
-  stdin: true
-- name: busybox1
-  image: busybox:latest
-  tty: true
-  stdin: true
+params:
+- prefix: naming prefix for the containers
+exports:
+- default: some sidecar containers
+  value: 
+  - name: ${prefix}-sidecar0
+    image: busybox:latest
+    tty: true
+    stdin: true
+    expose: asdf
+  - name: ${prefix}-sidecar1
+    image: busybox:latest
+    tty: true
+    stdin: true

--- a/examples/imports/bad-pod0.yaml
+++ b/examples/imports/bad-pod0.yaml
@@ -1,9 +1,24 @@
 imports:
 - affinity: ./bad-affinity.yaml
-- containers: ./bad-containers.yaml
-pod:
-  labels:
-    app: backend
-  name: backend
-  affinity: ${affinity}
-  containers: ${containers}
+  params:
+    this_app: ${name}
+    colocate_with: backend
+- sidecars: ./bad-containers.yaml
+  params:
+    prefix: ${name}
+params:
+- name: a name for the app
+exports:
+- default: the pod
+  value:
+    pod:
+      labels:
+        app: ${name}
+      name: ${name}
+      affinity: ${affinity}
+      containers:
+      - name: ${name}-container
+        image: busybox:latest
+        tty: true
+        stdin: true
+      - ${sidecars...}

--- a/examples/imports/containers.yaml
+++ b/examples/imports/containers.yaml
@@ -1,11 +1,19 @@
 params:
 - prefix: naming prefix for the containers
-containers:
-- name: ${prefix}-sidecar0
-  image: busybox:latest
-  tty: true
-  stdin: true
-- name: ${prefix}-sidecar1
-  image: busybox:latest
-  tty: true
-  stdin: true
+exports:
+- sidecars: some sidecar containers
+  value: 
+  - name: ${prefix}-sidecar0
+    image: busybox:latest
+    tty: true
+    stdin: true
+  - name: ${prefix}-sidecar1
+    image: busybox:latest
+    tty: true
+    stdin: true
+- dummy: a dummy container
+  value:
+    name: ${prefix}-dummy
+    image: busybox:latest
+    tty: true
+    stdin: true

--- a/examples/imports/pod0.yaml
+++ b/examples/imports/pod0.yaml
@@ -3,19 +3,22 @@ imports:
   params:
     this_app: ${name}
     colocate_with: backend
-- sidecars: ./containers.yaml
+- containers: ./containers.yaml
   params:
     prefix: ${name}
 params:
 - name: a name for the app
-pod:
-  labels:
-    app: ${name}
-  name: ${name}
-  affinity: ${affinity}
-  containers:
-  - name: ${name}-container
-    image: busybox:latest
-    tty: true
-    stdin: true
-  - ${sidecars...}
+exports:
+- default: the pod
+  value:
+    pod:
+      labels:
+        app: ${name}
+      name: ${name}
+      affinity: ${affinity}
+      containers:
+      - name: ${name}-container
+        image: busybox:latest
+        tty: true
+        stdin: true
+      - ${containers.sidecars...}

--- a/imports/template_resolver.go
+++ b/imports/template_resolver.go
@@ -1,0 +1,44 @@
+package imports
+
+import (
+	"strings"
+
+	"github.com/koki/short/template"
+	"github.com/koki/short/util"
+)
+
+func (c *EvalContext) ResolverForModule(module *Module, params map[string]interface{}) template.Resolver {
+	return template.Resolver(func(ident string) (interface{}, error) {
+		// Check params for the identifier.
+		if val, ok := params[ident]; ok {
+			return val, nil
+		}
+
+		// Check imports for the identifier.
+		identSegments := strings.Split(ident, ".")
+		importName := identSegments[0]
+		if len(identSegments) > 2 {
+			return nil, util.InvalidValueErrorf(ident, "cannot index into an imported resource. (%s) can have at most two segments. in module (%s)", ident, module.Path)
+		}
+		exportName := "default"
+		if len(identSegments) > 1 {
+			exportName = identSegments[1]
+		}
+
+		for _, imprt := range module.Imports {
+			if imprt.Name == importName {
+				// Make sure the Import has been evaluated.
+				err := c.EvaluateImport(module, params, imprt)
+				if err != nil {
+					return nil, err
+				}
+
+				if val, ok := imprt.Module.Exports[exportName]; ok {
+					return val.Raw, nil
+				}
+			}
+		}
+
+		return nil, util.InvalidValueErrorf(ident, "invalid template param (%s) for (%s)", ident, module.Path)
+	})
+}

--- a/imports/types.go
+++ b/imports/types.go
@@ -16,19 +16,24 @@ type ParamDef struct {
 	Default     interface{}
 }
 
+type Resource struct {
+	Description string
+	// Raw yaml parsed as string or map[string]interface{}
+	Raw interface{} `json:"Value"`
+
+	// TypedResult a koki object (or other object with special meaning)
+	TypedResult interface{} `json:"-"`
+}
+
 type Module struct {
 	Path    string              `json:"-"`
 	Imports []*Import           `json:"Imports,omitempty"`
 	Params  map[string]ParamDef `json:"Params,omitempty"`
 
-	// Raw yaml parsed as string or map[string]interface{}
-	Raw map[string]interface{} `json:"Contents"`
-
-	// IsEvaluated has the Raw yaml been evaluated (template holes filled, etc)?
+	// IsEvaluated has the Raw yaml in Exports been evaluated (template holes filled, etc)?
 	IsEvaluated bool `json:"-"`
 
-	// TypedResult a koki object (or other object with special meaning)
-	TypedResult interface{} `json:"-"`
+	Exports map[string]*Resource
 }
 
 type EvalContext struct {


### PR DESCRIPTION
#78 

@wlan0 

Syntax for exporting multiple resources from a "module" and selecting a specific resource from an imported module.

Design notes:
```
imports:
- pods_list: some/pod/pods-list-template.yaml
  params:
    param0: ...#some value
params:
- name: name of the application
- web_port: the port to use for the web app
  default: 80

# exported resources at the top level of the file?
# if there's only one resource, do we still need to give it a name?
# what about documentation for each exported value?
#   this syntax doesn't really support descriptions (see "app_pod" below)
custom_pod:
  pod:
    etc...
app_pod: ${pods_list.pod0}

# use a separate "exports" group. one entry per exported resource.
# terraform uses a "value" key like the one below.
exports:
- custom_pod: a pod we defined here
  value:
    pod:
      etc...
- app_pod: a pod we imported
  value: ${pods_list.pod0}

# if a module exports only one resource, we want to be able to use it like ${import_name}
# instead of always having to ${import_name.exported_name}
  
# if we allow "exports" to contain a single unnamed export,
#   how do we distinguish this from a single named export? how do we add a description?
exports: ${pods_list.pod0}
exports:
  pod:
    etc...
    
# we can use the name "default", which is how javascript solved this problem.
exports:
- default: a pod we imported
  value: ${pods_list.pod0}

exports:
- default: a pod we defined here
  value:
    pod:
      etc...

# if a yaml document contains no imports/params/exports
#   (i.e. a plain resource file, not a real module),
#   then it's equivalent to "exports: default: ${document contents}"
```