### PR TITLE
shorthand status for pv, rc, rs, deployment

### DIFF
--- a/converter/converters/koki_rc_to_kube_v1_rc.go
+++ b/converter/converters/koki_rc_to_kube_v1_rc.go
@@ -40,23 +40,75 @@ func Convert_Koki_ReplicationController_to_Kube_v1_ReplicationController(rc *typ
 	if kubeSpec.Template != nil {
 		if len(kubeSpec.Template.Labels) == 0 {
 			if len(kubeSpec.Selector) > 0 {
-				kokiRC.TemplateMetadata.Labels = kubeSpec.Selector
+				kubeSpec.Template.Labels = kubeSpec.Selector
 			} else {
-				kokiRC.TemplateMetadata.Labels = map[string]string{
+				kubeSpec.Template.Labels = map[string]string{
 					"koki.io/selector.name": kokiRC.Name,
 				}
-				kokiRC.Selector = map[string]string{
+				kubeSpec.Selector = map[string]string{
 					"koki.io/selector.name": kokiRC.Name,
 				}
 			}
 		}
 	}
 
-	if kokiRC.Status != nil {
-		kubeRC.Status = *kokiRC.Status
+	kubeRC.Status, err = revertReplicationControllerStatus(kokiRC.ReplicationControllerStatus)
+	if err != nil {
+		return nil, err
 	}
 
 	return kubeRC, nil
+}
+
+func revertReplicationControllerStatus(kokiStatus types.ReplicationControllerStatus) (v1.ReplicationControllerStatus, error) {
+	conditions, err := revertReplicationControllerConditions(kokiStatus.Conditions)
+	if err != nil {
+		return v1.ReplicationControllerStatus{}, err
+	}
+	return v1.ReplicationControllerStatus{
+		ObservedGeneration:   kokiStatus.ObservedGeneration,
+		Replicas:             kokiStatus.Replicas.Total,
+		FullyLabeledReplicas: kokiStatus.Replicas.FullyLabeled,
+		ReadyReplicas:        kokiStatus.Replicas.Ready,
+		AvailableReplicas:    kokiStatus.Replicas.Available,
+		Conditions:           conditions,
+	}, nil
+}
+
+func revertReplicationControllerConditions(kokiConditions []types.ReplicationControllerCondition) ([]v1.ReplicationControllerCondition, error) {
+	if len(kokiConditions) == 0 {
+		return nil, nil
+	}
+
+	kubeConditions := make([]v1.ReplicationControllerCondition, len(kokiConditions))
+	for i, condition := range kokiConditions {
+		status, err := revertConditionStatus(condition.Status)
+		if err != nil {
+			return nil, util.ContextualizeErrorf(err, "replica-set conditions[%d]", i)
+		}
+		conditionType, err := revertReplicationControllerConditionType(condition.Type)
+		if err != nil {
+			return nil, util.ContextualizeErrorf(err, "replica-set conditions[%d]", i)
+		}
+		kubeConditions[i] = v1.ReplicationControllerCondition{
+			Type:               conditionType,
+			Status:             status,
+			LastTransitionTime: condition.LastTransitionTime,
+			Reason:             condition.Reason,
+			Message:            condition.Message,
+		}
+	}
+
+	return kubeConditions, nil
+}
+
+func revertReplicationControllerConditionType(kokiType types.ReplicationControllerConditionType) (v1.ReplicationControllerConditionType, error) {
+	switch kokiType {
+	case types.ReplicationControllerReplicaFailure:
+		return v1.ReplicationControllerReplicaFailure, nil
+	default:
+		return v1.ReplicationControllerReplicaFailure, util.InvalidValueErrorf(kokiType, "unrecognized replica-set condition type")
+	}
 }
 
 func revertTemplate(kokiMeta *types.PodTemplateMeta, kokiSpec types.PodTemplate) (*v1.PodTemplateSpec, error) {

--- a/converter/converters/koki_replicaset_to_kube_replicaset.go
+++ b/converter/converters/koki_replicaset_to_kube_replicaset.go
@@ -124,11 +124,11 @@ func revertReplicaSetConditions(kokiConditions []types.ReplicaSetCondition) ([]a
 	for i, condition := range kokiConditions {
 		status, err := revertConditionStatus(condition.Status)
 		if err != nil {
-			return nil, util.ContextualizeErrorf(err, "deployment conditions[%d]", i)
+			return nil, util.ContextualizeErrorf(err, "replica-set conditions[%d]", i)
 		}
 		conditionType, err := revertReplicaSetConditionType(condition.Type)
 		if err != nil {
-			return nil, util.ContextualizeErrorf(err, "deployment conditions[%d]", i)
+			return nil, util.ContextualizeErrorf(err, "replica-set conditions[%d]", i)
 		}
 		kubeConditions[i] = appsv1beta2.ReplicaSetCondition{
 			Type:               conditionType,

--- a/converter/converters/kube_replicaset_to_koki_replicaset.go
+++ b/converter/converters/kube_replicaset_to_koki_replicaset.go
@@ -122,11 +122,11 @@ func convertReplicaSetConditions(kubeConditions []appsv1beta2.ReplicaSetConditio
 	for i, condition := range kubeConditions {
 		status, err := convertConditionStatus(condition.Status)
 		if err != nil {
-			return nil, util.ContextualizeErrorf(err, "deployment conditions[%d]", i)
+			return nil, util.ContextualizeErrorf(err, "replica-set conditions[%d]", i)
 		}
 		conditionType, err := convertReplicaSetConditionType(condition.Type)
 		if err != nil {
-			return nil, util.ContextualizeErrorf(err, "deployment conditions[%d]", i)
+			return nil, util.ContextualizeErrorf(err, "replica-set conditions[%d]", i)
 		}
 		kokiConditions[i] = types.ReplicaSetCondition{
 			Type:               conditionType,

--- a/converter/converters/kube_v1_rc_to_koki_rc.go
+++ b/converter/converters/kube_v1_rc_to_koki_rc.go
@@ -1,8 +1,6 @@
 package converters
 
 import (
-	"reflect"
-
 	"k8s.io/api/core/v1"
 
 	"github.com/koki/short/types"
@@ -10,6 +8,7 @@ import (
 )
 
 func Convert_Kube_v1_ReplicationController_to_Koki_ReplicationController(kubeRC *v1.ReplicationController) (*types.ReplicationControllerWrapper, error) {
+	var err error
 	kokiRC := &types.ReplicationController{}
 
 	kokiRC.Name = kubeRC.Name
@@ -33,13 +32,67 @@ func Convert_Kube_v1_ReplicationController_to_Koki_ReplicationController(kubeRC 
 		kokiRC.PodTemplate = template
 	}
 
-	if !reflect.DeepEqual(kubeRC.Status, v1.ReplicationControllerStatus{}) {
-		kokiRC.Status = &kubeRC.Status
+	kokiRC.ReplicationControllerStatus, err = convertReplicationControllerStatus(kubeRC.Status)
+	if err != nil {
+		return nil, err
 	}
 
 	return &types.ReplicationControllerWrapper{
 		ReplicationController: *kokiRC,
 	}, nil
+}
+
+func convertReplicationControllerStatus(kubeStatus v1.ReplicationControllerStatus) (types.ReplicationControllerStatus, error) {
+	conditions, err := convertReplicationControllerConditions(kubeStatus.Conditions)
+	if err != nil {
+		return types.ReplicationControllerStatus{}, err
+	}
+	return types.ReplicationControllerStatus{
+		ObservedGeneration: kubeStatus.ObservedGeneration,
+		Replicas: types.ReplicationControllerReplicasStatus{
+			Total:        kubeStatus.Replicas,
+			FullyLabeled: kubeStatus.FullyLabeledReplicas,
+			Ready:        kubeStatus.ReadyReplicas,
+			Available:    kubeStatus.AvailableReplicas,
+		},
+		Conditions: conditions,
+	}, nil
+}
+
+func convertReplicationControllerConditions(kubeConditions []v1.ReplicationControllerCondition) ([]types.ReplicationControllerCondition, error) {
+	if len(kubeConditions) == 0 {
+		return nil, nil
+	}
+
+	kokiConditions := make([]types.ReplicationControllerCondition, len(kubeConditions))
+	for i, condition := range kubeConditions {
+		status, err := convertConditionStatus(condition.Status)
+		if err != nil {
+			return nil, util.ContextualizeErrorf(err, "replication-controller conditions[%d]", i)
+		}
+		conditionType, err := convertReplicationControllerConditionType(condition.Type)
+		if err != nil {
+			return nil, util.ContextualizeErrorf(err, "replication-controller conditions[%d]", i)
+		}
+		kokiConditions[i] = types.ReplicationControllerCondition{
+			Type:               conditionType,
+			Status:             status,
+			LastTransitionTime: condition.LastTransitionTime,
+			Reason:             condition.Reason,
+			Message:            condition.Message,
+		}
+	}
+
+	return kokiConditions, nil
+}
+
+func convertReplicationControllerConditionType(kubeType v1.ReplicationControllerConditionType) (types.ReplicationControllerConditionType, error) {
+	switch kubeType {
+	case v1.ReplicationControllerReplicaFailure:
+		return types.ReplicationControllerReplicaFailure, nil
+	default:
+		return types.ReplicationControllerReplicaFailure, util.InvalidValueErrorf(kubeType, "unrecognized replication-controller condition type")
+	}
 }
 
 func convertTemplate(kubeTemplate v1.PodTemplateSpec) (*types.PodTemplateMeta, types.PodTemplate, error) {

--- a/testdata/deployments/deployment_spec_with_status.short.yaml
+++ b/testdata/deployments/deployment_spec_with_status.short.yaml
@@ -1,0 +1,29 @@
+deployment:
+  annotations:
+    meta: _test
+  cluster: test_cluster
+  condition:
+  - last_change: 2017-01-01T00:00:00Z
+    message: some message about this condition
+    reason: reasonForCondition
+    status: "true"
+    timestamp: 2017-01-01T00:00:00Z
+    type: available
+  generation_observed: 1
+  hash_collisions: 1
+  labels:
+    app: meta_test
+  max_revs: 32
+  min_ready: 32
+  name: meta_test
+  namespace: test
+  paused: true
+  progress_deadline: 32
+  replicas_status:
+    total: 1
+    updated: 1
+    ready: 1
+    available: 1
+    unavailable: 0
+  selector: koki.io/selector.name=meta_test
+  version: apps/v1beta1

--- a/testdata/deployments/deployment_spec_with_status.yaml
+++ b/testdata/deployments/deployment_spec_with_status.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    meta: _test
+  clusterName: test_cluster
+  creationTimestamp: null
+  labels:
+    app: meta_test
+  name: meta_test
+  namespace: test
+spec:
+  minReadySeconds: 32
+  paused: true
+  progressDeadlineSeconds: 32
+  revisionHistoryLimit: 32
+  selector:
+    matchLabels:
+      koki.io/selector.name: meta_test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        koki.io/selector.name: meta_test
+    spec:
+      containers: null
+status:
+  availableReplicas: 1
+  collisionCount: 1
+  conditions:
+  - lastTransitionTime: 2017-01-01T00:00:00Z
+    lastUpdateTime: 2017-01-01T00:00:00Z
+    message: some message about this condition
+    reason: reasonForCondition
+    status: "True"
+    type: Available
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+  updatedReplicas: 1
+

--- a/testdata/persistent_volumes/aws_ebs.short.yaml
+++ b/testdata/persistent_volumes/aws_ebs.short.yaml
@@ -15,9 +15,9 @@ persistent_volume:
   partition: 1
   reclaim: recycle
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: volume-id
   vol_type: aws_ebs
+

--- a/testdata/persistent_volumes/aws_ebs_with_status.short.yaml
+++ b/testdata/persistent_volumes/aws_ebs_with_status.short.yaml
@@ -5,22 +5,21 @@ persistent_volume:
     name: claimName
     namespace: claimNamespace
   cluster: cluster
+  fs: ext4
   labels:
     labelKey: labelValue
   modes: rw-once
-  monitors:
-  - 1.2.3.4:6789
-  - 1.2.3.5:6789
   mount_options: option 1,option 2,option 3
   name: vol-name
   namespace: namespace
-  path: /path
+  partition: 1
   reclaim: recycle
   ro: true
-  secret: file:/etc/ceph/admin.secret
+  status: available
+  status_message: the volume is available
+  status_reason: reasonForCurrentStatus
   storage: 10Gi
   storage_class: storageClass
-  user: admin
   version: v1
-  vol_type: cephfs
-
+  vol_id: volume-id
+  vol_type: aws_ebs

--- a/testdata/persistent_volumes/aws_ebs_with_status.yaml
+++ b/testdata/persistent_volumes/aws_ebs_with_status.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  annotations:
+    annotationKey: annotationValue
+  clusterName: cluster
+  creationTimestamp: null
+  labels:
+    labelKey: labelValue
+  name: vol-name
+  namespace: namespace
+spec:
+  accessModes:
+  - ReadWriteOnce
+  awsElasticBlockStore:
+    fsType: ext4
+    partition: 1
+    readOnly: true
+    volumeID: volume-id
+  capacity:
+    storage: 10Gi
+  claimRef:
+    name: claimName
+    namespace: claimNamespace
+  mountOptions:
+  - option 1
+  - option 2
+  - option 3
+  persistentVolumeReclaimPolicy: Recycle
+  storageClassName: storageClass
+status:
+  message: the volume is available
+  phase: Available
+  reason: reasonForCurrentStatus
+

--- a/testdata/persistent_volumes/azure_disk.short.yaml
+++ b/testdata/persistent_volumes/azure_disk.short.yaml
@@ -18,8 +18,8 @@ persistent_volume:
   namespace: namespace
   reclaim: recycle
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_type: azure_disk
+

--- a/testdata/persistent_volumes/azure_file.short.yaml
+++ b/testdata/persistent_volumes/azure_file.short.yaml
@@ -15,8 +15,8 @@ persistent_volume:
   ro: true
   secret: secret-namespace:secret-name
   share: k8stest
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_type: azure_file
+

--- a/testdata/persistent_volumes/cinder.short.yaml
+++ b/testdata/persistent_volumes/cinder.short.yaml
@@ -14,9 +14,9 @@ persistent_volume:
   namespace: namespace
   reclaim: recycle
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: bd82f7e2-wece-4c01-a505-4acf60b07f4a
   vol_type: cinder
+

--- a/testdata/persistent_volumes/fc.short.yaml
+++ b/testdata/persistent_volumes/fc.short.yaml
@@ -5,7 +5,6 @@ persistent_volume:
     name: claimName
     namespace: claimNamespace
   cluster: cluster
-  fs: ext4
   labels:
     labelKey: labelValue
   lun: 2
@@ -15,7 +14,6 @@ persistent_volume:
   namespace: namespace
   reclaim: recycle
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
@@ -26,3 +24,4 @@ persistent_volume:
   wwn:
   - 500a0982991b8dc5
   - 500a0982891b8dc5
+

--- a/testdata/persistent_volumes/flex.short.yaml
+++ b/testdata/persistent_volumes/flex.short.yaml
@@ -19,9 +19,9 @@ persistent_volume:
   reclaim: recycle
   ro: true
   secret: secret-name
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: kubernetes.io/lvm
   vol_type: flex
+

--- a/testdata/persistent_volumes/flocker.short.yaml
+++ b/testdata/persistent_volumes/flocker.short.yaml
@@ -12,9 +12,9 @@ persistent_volume:
   name: vol-name
   namespace: namespace
   reclaim: recycle
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: flocker_uuid
   vol_type: flocker
+

--- a/testdata/persistent_volumes/gce_pd.short.yaml
+++ b/testdata/persistent_volumes/gce_pd.short.yaml
@@ -15,9 +15,9 @@ persistent_volume:
   partition: 1
   reclaim: recycle
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: data-disk
   vol_type: gce_pd
+

--- a/testdata/persistent_volumes/glusterfs.short.yaml
+++ b/testdata/persistent_volumes/glusterfs.short.yaml
@@ -14,9 +14,9 @@ persistent_volume:
   namespace: namespace
   reclaim: recycle
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: kube_vol
   vol_type: glusterfs
+

--- a/testdata/persistent_volumes/host_path.short.yaml
+++ b/testdata/persistent_volumes/host_path.short.yaml
@@ -12,9 +12,9 @@ persistent_volume:
   name: vol-name
   namespace: namespace
   reclaim: recycle
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: /path:dir-or-create
   vol_type: host_path
+

--- a/testdata/persistent_volumes/iscsi.short.yaml
+++ b/testdata/persistent_volumes/iscsi.short.yaml
@@ -24,9 +24,9 @@ persistent_volume:
   reclaim: recycle
   ro: true
   secret: secret-name
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   target_portal: 1.2.3.4:3260
   version: v1
   vol_type: iscsi
+

--- a/testdata/persistent_volumes/local.short.yaml
+++ b/testdata/persistent_volumes/local.short.yaml
@@ -13,8 +13,8 @@ persistent_volume:
   namespace: namespace
   path: /some/path
   reclaim: recycle
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_type: local
+

--- a/testdata/persistent_volumes/nfs.short.yaml
+++ b/testdata/persistent_volumes/nfs.short.yaml
@@ -12,9 +12,9 @@ persistent_volume:
   name: vol-name
   namespace: namespace
   reclaim: recycle
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: hostname:/path:ro
   vol_type: nfs
+

--- a/testdata/persistent_volumes/photon.short.yaml
+++ b/testdata/persistent_volumes/photon.short.yaml
@@ -12,9 +12,9 @@ persistent_volume:
   name: vol-name
   namespace: namespace
   reclaim: recycle
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: some-pdid:ext4
   vol_type: photon
+

--- a/testdata/persistent_volumes/portworx.short.yaml
+++ b/testdata/persistent_volumes/portworx.short.yaml
@@ -14,9 +14,9 @@ persistent_volume:
   namespace: namespace
   reclaim: recycle
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: volume-id
   vol_type: portworx
+

--- a/testdata/persistent_volumes/quobyte.short.yaml
+++ b/testdata/persistent_volumes/quobyte.short.yaml
@@ -15,10 +15,10 @@ persistent_volume:
   reclaim: recycle
   registry: registry:6789
   ro: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   user: root
   version: v1
   vol_id: testVolume
   vol_type: quobyte
+

--- a/testdata/persistent_volumes/rbd.short.yaml
+++ b/testdata/persistent_volumes/rbd.short.yaml
@@ -21,9 +21,9 @@ persistent_volume:
   reclaim: recycle
   ro: true
   secret: secret-namespace:secret-name
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   user: admin
   version: v1
   vol_type: rbd
+

--- a/testdata/persistent_volumes/scaleio.short.yaml
+++ b/testdata/persistent_volumes/scaleio.short.yaml
@@ -18,7 +18,6 @@ persistent_volume:
   ro: true
   secret: secret-namespace:secret-name
   ssl: true
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   storage_mode: ThickProvisioned
@@ -27,3 +26,4 @@ persistent_volume:
   version: v1
   vol_id: vol-0
   vol_type: scaleio
+

--- a/testdata/persistent_volumes/storageos.short.yaml
+++ b/testdata/persistent_volumes/storageos.short.yaml
@@ -15,10 +15,10 @@ persistent_volume:
   reclaim: recycle
   ro: true
   secret: secret-namespace:secret-name
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: vol-0
   vol_namespace: namespace-0
   vol_type: storageos
+

--- a/testdata/persistent_volumes/vsphere.short.yaml
+++ b/testdata/persistent_volumes/vsphere.short.yaml
@@ -16,9 +16,9 @@ persistent_volume:
     id: policy-id
     name: policy-name
   reclaim: recycle
-  status: {}
   storage: 10Gi
   storage_class: storageClass
   version: v1
   vol_id: '[datastore1] volumes/myDisk'
   vol_type: vsphere
+

--- a/testdata/replica_sets/replicaset_spec_with_status.short.yaml
+++ b/testdata/replica_sets/replicaset_spec_with_status.short.yaml
@@ -1,0 +1,28 @@
+replica_set:
+  annotations:
+    meta: _test
+  cluster: test_cluster
+  condition:
+  - last_change: 2017-01-01T00:00:00Z
+    message: some message about this condition
+    reason: reasonForCondition
+    status: "true"
+    type: replica-failure
+  containers:
+  - image: redis
+    name: redis
+  generation_observed: 1
+  labels:
+    app: meta_test
+  name: meta_test
+  namespace: test
+  replicas: 1
+  replicas_status:
+    total: 1
+    fully_labeled: 1
+    ready: 1
+    available: 1
+  selector:
+    app: redis
+  version: apps/v1beta2
+

--- a/testdata/replica_sets/replicaset_spec_with_status.yaml
+++ b/testdata/replica_sets/replicaset_spec_with_status.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1beta2
+kind: ReplicaSet
+metadata:
+  annotations:
+    meta: _test
+  clusterName: test_cluster
+  creationTimestamp: null
+  labels:
+    app: meta_test
+  name: meta_test
+  namespace: test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: redis
+        name: redis
+        resources: {}
+status:
+  availableReplicas: 1
+  conditions:
+  - lastTransitionTime: 2017-01-01T00:00:00Z
+    message: some message about this condition
+    reason: reasonForCondition
+    status: "True"
+    type: ReplicaFailure
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+

--- a/testdata/replication_controllers/replication_controller_spec_with_status.short.yaml
+++ b/testdata/replication_controllers/replication_controller_spec_with_status.short.yaml
@@ -1,0 +1,28 @@
+replication_controller:
+  annotations:
+    meta: _test
+  cluster: test_cluster
+  condition:
+  - last_change: 2017-01-01T00:00:00Z
+    message: some message about this condition
+    reason: reasonForCondition
+    status: "true"
+    type: replica-failure
+  containers:
+  - image: redis
+    name: redis
+  generation_observed: 1
+  labels:
+    app: meta_test
+  name: meta_test
+  namespace: test
+  ready_seconds: 32
+  replicas: 1
+  replicas_status:
+    total: 1
+    fully_labeled: 1
+    ready: 1
+    available: 1
+  selector:
+    app: redis
+  version: v1

--- a/testdata/replication_controllers/replication_controller_spec_with_status.yaml
+++ b/testdata/replication_controllers/replication_controller_spec_with_status.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  annotations:
+    meta: _test
+  clusterName: test_cluster
+  creationTimestamp: null
+  labels:
+    app: meta_test
+  name: meta_test
+  namespace: test
+spec:
+  minReadySeconds: 32
+  replicas: 1
+  selector:
+    app: redis
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: redis
+    spec:
+      containers:
+      - image: redis
+        name: redis
+        resources: {}
+status:
+  availableReplicas: 1
+  conditions:
+  - lastTransitionTime: 2017-01-01T00:00:00Z
+    message: some message about this condition
+    reason: reasonForCondition
+    status: "True"
+    type: ReplicaFailure
+  fullyLabeledReplicas: 1
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+

--- a/types/deployment.go
+++ b/types/deployment.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	apps "k8s.io/api/apps/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -28,115 +27,46 @@ type Deployment struct {
 	Paused                  bool   `json:"paused,omitempty"`
 	ProgressDeadlineSeconds *int32 `json:"progress_deadline,omitempty"`
 
-	Status *apps.DeploymentStatus `json:"status,omitempty"`
-
 	// Selector in ReplicaSet can express more complex rules than just matching
 	// pod labels, so it needs its own field (unlike in ReplicationController).
 	// Leaving it blank has the same effect as omitting Selector in RC.
 	Selector *RSSelector `json:"selector,omitempty"`
 
-	// Template fields
-	TemplateMetadata       *RSTemplateMetadata `json:"pod_meta,omitempty"`
-	Volumes                map[string]Volume   `json:"volumes,omitempty"`
-	Affinity               []Affinity          `json:"affinity,omitempty"`
-	Containers             []Container         `json:"containers,omitempty"`
-	InitContainers         []Container         `json:"init_containers,omitempty"`
-	DNSPolicy              DNSPolicy           `json:"dns_policy,omitempty"`
-	HostAliases            []string            `json:"host_aliases,omitempty"`
-	HostMode               []HostMode          `json:"host_mode,omitempty"`
-	Hostname               string              `json:"hostname,omitempty"`
-	Registries             []string            `json:"registry_secrets,omitempty"`
-	RestartPolicy          RestartPolicy       `json:"restart_policy,omitempty"`
-	SchedulerName          string              `json:"scheduler_name,omitempty"`
-	Account                string              `json:"account,omitempty"`
-	Tolerations            []Toleration        `json:"tolerations,omitempty"`
-	TerminationGracePeriod *int64              `json:"termination_grace_period,omitempty"`
-	ActiveDeadline         *int64              `json:"active_deadline,omitempty"`
-	Node                   string              `json:"node,omitempty"`
-	Priority               *Priority           `json:"priority,omitempty"`
-	Conditions             []PodCondition      `json:"condition,omitempty"`
-	NodeIP                 string              `json:"node_ip,omitempty"`
-	StartTime              *metav1.Time        `json:"start_time,omitempty"`
-	Msg                    string              `json:"msg,omitempty"`
-	Phase                  PodPhase            `json:"phase,omitempty"`
-	IP                     string              `json:"ip,omitempty"`
-	QOS                    PodQOSClass         `json:"qos,omitempty"`
-	Reason                 string              `json:"reason,omitempty"`
-	FSGID                  *int64              `json:"fs_gid,omitempty"`
-	GIDs                   []int64             `json:"gids,omitempty"`
+	TemplateMetadata *PodTemplateMeta `json:"pod_meta,omitempty"`
+	PodTemplate      `json:",inline"`
+
+	// Status
+	DeploymentStatus `json:",inline"`
 }
 
-func (d *Deployment) SetTemplate(pod *Pod) {
-	d.TemplateMetadata = RSTemplateMetadataFromPod(pod)
-	d.Volumes = pod.Volumes
-	d.Affinity = pod.Affinity
-	d.Containers = pod.Containers
-	d.InitContainers = pod.InitContainers
-	d.DNSPolicy = pod.DNSPolicy
-	d.HostAliases = pod.HostAliases
-	d.HostMode = pod.HostMode
-	d.Hostname = pod.Hostname
-	d.Registries = pod.Registries
-	d.RestartPolicy = pod.RestartPolicy
-	d.SchedulerName = pod.SchedulerName
-	d.Account = pod.Account
-	d.Tolerations = pod.Tolerations
-	d.TerminationGracePeriod = pod.TerminationGracePeriod
-
-	d.ActiveDeadline = pod.ActiveDeadline
-	d.Node = pod.Node
-	d.Priority = pod.Priority
-	d.Conditions = pod.Conditions
-	d.NodeIP = pod.NodeIP
-	d.StartTime = pod.StartTime
-	d.Msg = pod.Msg
-	d.Phase = pod.Phase
-	d.IP = pod.IP
-	d.QOS = pod.QOS
-	d.Reason = pod.Reason
-	d.FSGID = pod.FSGID
-	d.GIDs = pod.GIDs
+type DeploymentStatus struct {
+	ObservedGeneration int64                    `json:"generation_observed,omitempty"`
+	Replicas           DeploymentReplicasStatus `json:"replicas_status,omitempty"`
+	Conditions         []DeploymentCondition    `json:"condition,omitempty"`
+	CollisionCount     *int32                   `json:"hash_collisions,omitempty"`
 }
 
-func (d *Deployment) GetTemplate() *Pod {
-	pod := Pod{}
+type DeploymentReplicasStatus struct {
+	Total       int32 `json:"total,omitempty"`
+	Updated     int32 `json:"updated,omitempty"`
+	Ready       int32 `json:"ready,omitempty"`
+	Available   int32 `json:"available,omitempty"`
+	Unavailable int32 `json:"unavailable,omitempty"`
+}
 
-	if d.TemplateMetadata != nil {
-		pod.Cluster = d.TemplateMetadata.Cluster
-		pod.Name = d.TemplateMetadata.Name
-		pod.Namespace = d.TemplateMetadata.Namespace
-		pod.Labels = d.TemplateMetadata.Labels
-		pod.Annotations = d.TemplateMetadata.Annotations
-	}
+type DeploymentConditionType string
 
-	pod.Volumes = d.Volumes
-	pod.Affinity = d.Affinity
-	pod.Containers = d.Containers
-	pod.InitContainers = d.InitContainers
-	pod.DNSPolicy = d.DNSPolicy
-	pod.HostAliases = d.HostAliases
-	pod.HostMode = d.HostMode
-	pod.Hostname = d.Hostname
-	pod.Registries = d.Registries
-	pod.RestartPolicy = d.RestartPolicy
-	pod.SchedulerName = d.SchedulerName
-	pod.Account = d.Account
-	pod.Tolerations = d.Tolerations
-	pod.TerminationGracePeriod = d.TerminationGracePeriod
+const (
+	DeploymentAvailable      DeploymentConditionType = "available"
+	DeploymentProgressing    DeploymentConditionType = "progressing"
+	DeploymentReplicaFailure DeploymentConditionType = "replica-failure"
+)
 
-	pod.ActiveDeadline = d.ActiveDeadline
-	pod.Node = d.Node
-	pod.Priority = d.Priority
-	pod.Conditions = d.Conditions
-	pod.NodeIP = d.NodeIP
-	pod.StartTime = d.StartTime
-	pod.Msg = d.Msg
-	pod.Phase = d.Phase
-	pod.IP = d.IP
-	pod.QOS = d.QOS
-	pod.Reason = d.Reason
-	pod.FSGID = d.FSGID
-	pod.GIDs = d.GIDs
-
-	return &pod
+type DeploymentCondition struct {
+	Type               DeploymentConditionType `json:"type"`
+	Status             ConditionStatus         `json:"status"`
+	LastUpdateTime     metav1.Time             `json:"timestamp,omitempty"`
+	LastTransitionTime metav1.Time             `json:"last_change,omitempty"`
+	Reason             string                  `json:"reason,omitempty"`
+	Message            string                  `json:"message,omitempty"`
 }

--- a/types/persistentvolume.go
+++ b/types/persistentvolume.go
@@ -38,8 +38,24 @@ type PersistentVolumeMeta struct {
 	// comma-separated list of options
 	MountOptions string `json:"mount_options,omitempty" protobuf:"bytes,7,opt,name=mountOptions"`
 
-	Status *v1.PersistentVolumeStatus `json:"status,omitempty"`
+	PersistentVolumeStatus `json:",inline"`
 }
+
+type PersistentVolumeStatus struct {
+	Phase   PersistentVolumePhase `json:"status,omitempty"`
+	Message string                `json:"status_message,omitempty"`
+	Reason  string                `json:"status_reason,omitempty"`
+}
+
+type PersistentVolumePhase string
+
+const (
+	VolumePending   PersistentVolumePhase = "pending"
+	VolumeAvailable PersistentVolumePhase = "available"
+	VolumeBound     PersistentVolumePhase = "bound"
+	VolumeReleased  PersistentVolumePhase = "released"
+	VolumeFailed    PersistentVolumePhase = "failed"
+)
 
 type PersistentVolumeReclaimPolicy string
 

--- a/types/persistentvolume_test.go
+++ b/types/persistentvolume_test.go
@@ -242,7 +242,11 @@ func testPersistentVolumeSource(v PersistentVolumeSource, t *testing.T) {
 			ReclaimPolicy: PersistentVolumeReclaimRecycle,
 			StorageClass:  "storageClass",
 			MountOptions:  "option 1,option 2,option 3",
-			Status:        &v1.PersistentVolumeStatus{},
+			PersistentVolumeStatus: PersistentVolumeStatus{
+				Phase:   VolumeAvailable,
+				Message: "user-friendly message about the status",
+				Reason:  "machineFriendlyReasonForStatus",
+			},
 		},
 		PersistentVolumeSource: v,
 	}

--- a/types/pod.go
+++ b/types/pod.go
@@ -9,39 +9,49 @@ type PodWrapper struct {
 }
 
 type Pod struct {
-	Version                string            `json:"version,omitempty"`
-	Cluster                string            `json:"cluster,omitempty"`
-	Name                   string            `json:"name,omitempty"`
-	Namespace              string            `json:"namespace,omitempty"`
-	Labels                 map[string]string `json:"labels,omitempty"`
-	Annotations            map[string]string `json:"annotations,omitempty"`
+	Version string `json:"version,omitempty"`
+
+	Conditions []PodCondition `json:"condition,omitempty"`
+	NodeIP     string         `json:"node_ip,omitempty"`
+	StartTime  *metav1.Time   `json:"start_time,omitempty"`
+	Msg        string         `json:"msg,omitempty"`
+	Phase      PodPhase       `json:"phase,omitempty"`
+	IP         string         `json:"ip,omitempty"`
+	QOS        PodQOSClass    `json:"qos,omitempty"`
+	Reason     string         `json:"reason,omitempty"`
+
+	PodTemplateMeta `json:",inline"`
+	PodTemplate     `json:",inline"`
+}
+
+type PodTemplateMeta struct {
+	Cluster     string            `json:"cluster,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type PodTemplate struct {
 	Volumes                map[string]Volume `json:"volumes,omitempty"`
-	Affinity               []Affinity        `json:"affinity,omitempty"`
-	Containers             []Container       `json:"containers,omitempty"`
 	InitContainers         []Container       `json:"init_containers,omitempty"`
-	DNSPolicy              DNSPolicy         `json:"dns_policy,omitempty"`
-	HostAliases            []string          `json:"host_aliases,omitempty"`
-	HostMode               []HostMode        `json:"host_mode,omitempty"`
-	Hostname               string            `json:"hostname,omitempty"`
-	Registries             []string          `json:"registry_secrets,omitempty"`
+	Containers             []Container       `json:"containers,omitempty"`
 	RestartPolicy          RestartPolicy     `json:"restart_policy,omitempty"`
-	SchedulerName          string            `json:"scheduler_name,omitempty"`
-	Account                string            `json:"account,omitempty"`
-	Tolerations            []Toleration      `json:"tolerations,omitempty"`
 	TerminationGracePeriod *int64            `json:"termination_grace_period,omitempty"`
 	ActiveDeadline         *int64            `json:"active_deadline,omitempty"`
+	DNSPolicy              DNSPolicy         `json:"dns_policy,omitempty"`
+	Account                string            `json:"account,omitempty"`
 	Node                   string            `json:"node,omitempty"`
-	Priority               *Priority         `json:"priority,omitempty"`
-	Conditions             []PodCondition    `json:"condition,omitempty"`
-	NodeIP                 string            `json:"node_ip,omitempty"`
-	StartTime              *metav1.Time      `json:"start_time,omitempty"`
-	Msg                    string            `json:"msg,omitempty"`
-	Phase                  PodPhase          `json:"phase,omitempty"`
-	IP                     string            `json:"ip,omitempty"`
-	QOS                    PodQOSClass       `json:"qos,omitempty"`
-	Reason                 string            `json:"reason,omitempty"`
+	HostMode               []HostMode        `json:"host_mode,omitempty"`
 	FSGID                  *int64            `json:"fs_gid,omitempty"`
 	GIDs                   []int64           `json:"gids,omitempty"`
+	Registries             []string          `json:"registry_secrets,omitempty"`
+	Hostname               string            `json:"hostname,omitempty"`
+	Affinity               []Affinity        `json:"affinity,omitempty"`
+	SchedulerName          string            `json:"scheduler_name,omitempty"`
+	Tolerations            []Toleration      `json:"tolerations,omitempty"`
+	HostAliases            []string          `json:"host_aliases,omitempty"`
+	Priority               *Priority         `json:"priority,omitempty"`
 }
 
 type Priority struct {

--- a/types/replicaset.go
+++ b/types/replicaset.go
@@ -2,10 +2,8 @@ package types
 
 import (
 	"encoding/json"
-	"reflect"
 
 	apps "k8s.io/api/apps/v1beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/koki/short/util"
 )
@@ -32,138 +30,13 @@ type ReplicaSet struct {
 	// Leaving it blank has the same effect as omitting Selector in RC.
 	Selector *RSSelector `json:"selector,omitempty"`
 
-	// Template fields
-	TemplateMetadata       *RSTemplateMetadata `json:"pod_meta,omitempty"`
-	Volumes                map[string]Volume   `json:"volumes,omitempty"`
-	Affinity               []Affinity          `json:"affinity,omitempty"`
-	Containers             []Container         `json:"containers,omitempty"`
-	InitContainers         []Container         `json:"init_containers,omitempty"`
-	DNSPolicy              DNSPolicy           `json:"dns_policy,omitempty"`
-	HostAliases            []string            `json:"host_aliases,omitempty"`
-	HostMode               []HostMode          `json:"host_mode,omitempty"`
-	Hostname               string              `json:"hostname,omitempty"`
-	Registries             []string            `json:"registry_secrets,omitempty"`
-	RestartPolicy          RestartPolicy       `json:"restart_policy,omitempty"`
-	SchedulerName          string              `json:"scheduler_name,omitempty"`
-	Account                string              `json:"account,omitempty"`
-	Tolerations            []Toleration        `json:"tolerations,omitempty"`
-	TerminationGracePeriod *int64              `json:"termination_grace_period,omitempty"`
-	ActiveDeadline         *int64              `json:"active_deadline,omitempty"`
-	Node                   string              `json:"node,omitempty"`
-	Priority               *Priority           `json:"priority,omitempty"`
-	Conditions             []PodCondition      `json:"condition,omitempty"`
-	NodeIP                 string              `json:"node_ip,omitempty"`
-	StartTime              *metav1.Time        `json:"start_time,omitempty"`
-	Msg                    string              `json:"msg,omitempty"`
-	Phase                  PodPhase            `json:"phase,omitempty"`
-	IP                     string              `json:"ip,omitempty"`
-	QOS                    PodQOSClass         `json:"qos,omitempty"`
-	Reason                 string              `json:"reason,omitempty"`
-	FSGID                  *int64              `json:"fs_gid,omitempty"`
-	GIDs                   []int64             `json:"gids,omitempty"`
-}
-
-type RSTemplateMetadata struct {
-	Cluster     string            `json:"cluster,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	Namespace   string            `json:"namespace,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	TemplateMetadata *PodTemplateMeta `json:"pod_meta,omitempty"`
+	PodTemplate      `json:",inline"`
 }
 
 type RSSelector struct {
 	Shorthand string
 	Labels    map[string]string
-}
-
-func RSTemplateMetadataFromPod(pod *Pod) *RSTemplateMetadata {
-	meta := RSTemplateMetadata{}
-	meta.Cluster = pod.Cluster
-	meta.Name = pod.Name
-	meta.Namespace = pod.Namespace
-	meta.Labels = pod.Labels
-	meta.Annotations = pod.Annotations
-
-	if reflect.DeepEqual(meta, RSTemplateMetadata{}) {
-		return nil
-	}
-
-	return &meta
-}
-
-func (rs *ReplicaSet) SetTemplate(pod *Pod) {
-	rs.TemplateMetadata = RSTemplateMetadataFromPod(pod)
-	rs.Volumes = pod.Volumes
-	rs.Affinity = pod.Affinity
-	rs.Containers = pod.Containers
-	rs.InitContainers = pod.InitContainers
-	rs.DNSPolicy = pod.DNSPolicy
-	rs.HostAliases = pod.HostAliases
-	rs.HostMode = pod.HostMode
-	rs.Hostname = pod.Hostname
-	rs.Registries = pod.Registries
-	rs.RestartPolicy = pod.RestartPolicy
-	rs.SchedulerName = pod.SchedulerName
-	rs.Account = pod.Account
-	rs.Tolerations = pod.Tolerations
-	rs.TerminationGracePeriod = pod.TerminationGracePeriod
-
-	rs.ActiveDeadline = pod.ActiveDeadline
-	rs.Node = pod.Node
-	rs.Priority = pod.Priority
-	rs.Conditions = pod.Conditions
-	rs.NodeIP = pod.NodeIP
-	rs.StartTime = pod.StartTime
-	rs.Msg = pod.Msg
-	rs.Phase = pod.Phase
-	rs.IP = pod.IP
-	rs.QOS = pod.QOS
-	rs.Reason = pod.Reason
-	rs.FSGID = pod.FSGID
-	rs.GIDs = pod.GIDs
-}
-
-func (rs *ReplicaSet) GetTemplate() *Pod {
-	pod := Pod{}
-
-	if rs.TemplateMetadata != nil {
-		pod.Cluster = rs.TemplateMetadata.Cluster
-		pod.Name = rs.TemplateMetadata.Name
-		pod.Namespace = rs.TemplateMetadata.Namespace
-		pod.Labels = rs.TemplateMetadata.Labels
-		pod.Annotations = rs.TemplateMetadata.Annotations
-	}
-
-	pod.Volumes = rs.Volumes
-	pod.Affinity = rs.Affinity
-	pod.Containers = rs.Containers
-	pod.InitContainers = rs.InitContainers
-	pod.DNSPolicy = rs.DNSPolicy
-	pod.HostAliases = rs.HostAliases
-	pod.HostMode = rs.HostMode
-	pod.Hostname = rs.Hostname
-	pod.Registries = rs.Registries
-	pod.RestartPolicy = rs.RestartPolicy
-	pod.SchedulerName = rs.SchedulerName
-	pod.Account = rs.Account
-	pod.Tolerations = rs.Tolerations
-	pod.TerminationGracePeriod = rs.TerminationGracePeriod
-
-	pod.ActiveDeadline = rs.ActiveDeadline
-	pod.Node = rs.Node
-	pod.Priority = rs.Priority
-	pod.Conditions = rs.Conditions
-	pod.NodeIP = rs.NodeIP
-	pod.StartTime = rs.StartTime
-	pod.Msg = rs.Msg
-	pod.Phase = rs.Phase
-	pod.IP = rs.IP
-	pod.QOS = rs.QOS
-	pod.Reason = rs.Reason
-	pod.FSGID = rs.FSGID
-	pod.GIDs = rs.GIDs
-
-	return &pod
 }
 
 func (s *RSSelector) UnmarshalJSON(data []byte) error {

--- a/types/replicationcontroller.go
+++ b/types/replicationcontroller.go
@@ -1,10 +1,7 @@
 package types
 
 import (
-	"reflect"
-
 	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ReplicationControllerWrapper struct {
@@ -29,132 +26,6 @@ type ReplicationController struct {
 	Selector map[string]string `json:"selector,omitempty"`
 
 	// Template fields
-	TemplateMetadata       *RCTemplateMetadata `json:"pod_meta,omitempty"`
-	Volumes                map[string]Volume   `json:"volumes,omitempty"`
-	Affinity               []Affinity          `json:"affinity,omitempty"`
-	Containers             []Container         `json:"containers,omitempty"`
-	InitContainers         []Container         `json:"init_containers,omitempty"`
-	DNSPolicy              DNSPolicy           `json:"dns_policy,omitempty"`
-	HostAliases            []string            `json:"host_aliases,omitempty"`
-	HostMode               []HostMode          `json:"host_mode,omitempty"`
-	Hostname               string              `json:"hostname,omitempty"`
-	Registries             []string            `json:"registry_secrets,omitempty"`
-	RestartPolicy          RestartPolicy       `json:"restart_policy,omitempty"`
-	SchedulerName          string              `json:"scheduler_name,omitempty"`
-	Account                string              `json:"account,omitempty"`
-	Tolerations            []Toleration        `json:"tolerations,omitempty"`
-	TerminationGracePeriod *int64              `json:"termination_grace_period,omitempty"`
-	ActiveDeadline         *int64              `json:"active_deadline,omitempty"`
-	Node                   string              `json:"node,omitempty"`
-	Priority               *Priority           `json:"priority,omitempty"`
-	Conditions             []PodCondition      `json:"condition,omitempty"`
-	NodeIP                 string              `json:"node_ip,omitempty"`
-	StartTime              *metav1.Time        `json:"start_time,omitempty"`
-	Msg                    string              `json:"msg,omitempty"`
-	Phase                  PodPhase            `json:"phase,omitempty"`
-	IP                     string              `json:"ip,omitempty"`
-	QOS                    PodQOSClass         `json:"qos,omitempty"`
-	Reason                 string              `json:"reason,omitempty"`
-	FSGID                  *int64              `json:"fs_gid,omitempty"`
-	GIDs                   []int64             `json:"gids,omitempty"`
-}
-
-type RCTemplateMetadata struct {
-	Cluster     string            `json:"cluster,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	Namespace   string            `json:"namespace,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
-}
-
-func RCTemplateMetadataFromPod(pod *Pod) *RCTemplateMetadata {
-	meta := RCTemplateMetadata{}
-	meta.Cluster = pod.Cluster
-	meta.Name = pod.Name
-	meta.Namespace = pod.Namespace
-	meta.Annotations = pod.Annotations
-
-	if reflect.DeepEqual(meta, RCTemplateMetadata{}) {
-		return nil
-	}
-
-	return &meta
-}
-
-func (rc *ReplicationController) SetTemplate(pod *Pod) {
-	rc.TemplateMetadata = RCTemplateMetadataFromPod(pod)
-
-	rc.Selector = pod.Labels
-
-	rc.Volumes = pod.Volumes
-	rc.Affinity = pod.Affinity
-	rc.Containers = pod.Containers
-	rc.InitContainers = pod.InitContainers
-	rc.DNSPolicy = pod.DNSPolicy
-	rc.HostAliases = pod.HostAliases
-	rc.HostMode = pod.HostMode
-	rc.Hostname = pod.Hostname
-	rc.Registries = pod.Registries
-	rc.RestartPolicy = pod.RestartPolicy
-	rc.SchedulerName = pod.SchedulerName
-	rc.Account = pod.Account
-	rc.Tolerations = pod.Tolerations
-	rc.TerminationGracePeriod = pod.TerminationGracePeriod
-
-	rc.ActiveDeadline = pod.ActiveDeadline
-	rc.Node = pod.Node
-	rc.Priority = pod.Priority
-	rc.Conditions = pod.Conditions
-	rc.NodeIP = pod.NodeIP
-	rc.StartTime = pod.StartTime
-	rc.Msg = pod.Msg
-	rc.Phase = pod.Phase
-	rc.IP = pod.IP
-	rc.QOS = pod.QOS
-	rc.Reason = pod.Reason
-	rc.FSGID = pod.FSGID
-	rc.GIDs = pod.GIDs
-}
-
-func (rc *ReplicationController) GetTemplate() *Pod {
-	pod := Pod{}
-
-	if rc.TemplateMetadata != nil {
-		pod.Cluster = rc.TemplateMetadata.Cluster
-		pod.Name = rc.TemplateMetadata.Name
-		pod.Namespace = rc.TemplateMetadata.Namespace
-		pod.Annotations = rc.TemplateMetadata.Annotations
-	}
-
-	pod.Labels = rc.Selector
-
-	pod.Volumes = rc.Volumes
-	pod.Affinity = rc.Affinity
-	pod.Containers = rc.Containers
-	pod.InitContainers = rc.InitContainers
-	pod.DNSPolicy = rc.DNSPolicy
-	pod.HostAliases = rc.HostAliases
-	pod.HostMode = rc.HostMode
-	pod.Hostname = rc.Hostname
-	pod.Registries = rc.Registries
-	pod.RestartPolicy = rc.RestartPolicy
-	pod.SchedulerName = rc.SchedulerName
-	pod.Account = rc.Account
-	pod.Tolerations = rc.Tolerations
-	pod.TerminationGracePeriod = rc.TerminationGracePeriod
-
-	pod.ActiveDeadline = rc.ActiveDeadline
-	pod.Node = rc.Node
-	pod.Priority = rc.Priority
-	pod.Conditions = rc.Conditions
-	pod.NodeIP = rc.NodeIP
-	pod.StartTime = rc.StartTime
-	pod.Msg = rc.Msg
-	pod.Phase = rc.Phase
-	pod.IP = rc.IP
-	pod.QOS = rc.QOS
-	pod.Reason = rc.Reason
-	pod.FSGID = rc.FSGID
-	pod.GIDs = rc.GIDs
-
-	return &pod
+	TemplateMetadata *PodTemplateMeta `json:"pod_meta,omitempty"`
+	PodTemplate      `json:",inline"`
 }

--- a/types/replicationcontroller.go
+++ b/types/replicationcontroller.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ReplicationControllerWrapper struct {
@@ -19,8 +19,6 @@ type ReplicationController struct {
 	Replicas        *int32 `json:"replicas,omitempty"`
 	MinReadySeconds int32  `json:"ready_seconds,omitempty"`
 
-	Status *v1.ReplicationControllerStatus `json:"status,omitempty"`
-
 	// Selector and the Template's Labels are expected to be equal
 	// if both exist, so we standardize on using the Template's labels.
 	Selector map[string]string `json:"selector,omitempty"`
@@ -28,4 +26,35 @@ type ReplicationController struct {
 	// Template fields
 	TemplateMetadata *PodTemplateMeta `json:"pod_meta,omitempty"`
 	PodTemplate      `json:",inline"`
+
+	// Status
+	ReplicationControllerStatus `json:",inline"`
+}
+
+type ReplicationControllerStatus struct {
+	ObservedGeneration int64                               `json:"generation_observed,omitempty"`
+	Replicas           ReplicationControllerReplicasStatus `json:"replicas_status,omitempty"`
+	Conditions         []ReplicationControllerCondition    `json:"condition,omitempty"`
+}
+
+type ReplicationControllerReplicasStatus struct {
+	Total        int32 `json:"total,omitempty"`
+	FullyLabeled int32 `json:"fully_labeled,omitempty"`
+	Ready        int32 `json:"ready,omitempty"`
+	Available    int32 `json:"available,omitempty"`
+}
+
+type ReplicationControllerConditionType string
+
+const (
+	ReplicationControllerReplicaFailure ReplicationControllerConditionType = "replica-failure"
+)
+
+// ReplicationControllerCondition describes the state of a replica set at a certain point.
+type ReplicationControllerCondition struct {
+	Type               ReplicationControllerConditionType `json:"type"`
+	Status             ConditionStatus                    `json:"status"`
+	LastTransitionTime metav1.Time                        `json:"last_change,omitempty"`
+	Reason             string                             `json:"reason,omitempty"`
+	Message            string                             `json:"message,omitempty"`
 }


### PR DESCRIPTION
moved pod template to its own type, so the pod status fields wouldn't collide with rc/rs/deployment status fields. also to reduce duplication.

shorthand for status field of:
* persistent volume
* rc/rs
* deployment

@wlan0 