### PR TITLE
fix flaky affinities test: sort affinity exprs from matchlabels

### DIFF
--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -198,14 +198,15 @@ func testFuncGenerator(t *testing.T) func(string, filePair) error {
 			t.Fatalf("\nconverted(%d)=\n%s\nunconverted(%d)=\n%s \n", len(cb), cb, len(ucb), ucb)
 		}*/
 
-		equal, err := cmp.CompareReader(convertedKokiObj, unconvertedKokiObj)
+		convertedKokiObjString := convertedKokiObj.String()
+		equal, err := cmp.CompareReader(bytes.NewBufferString(convertedKokiObjString), unconvertedKokiObj)
 		if err != nil {
 			t.Errorf("path %s err %v", path, err)
 			return err
 		}
 
 		if !equal {
-			t.Errorf("Failed to translate from Kube To Koki types. Resource Path=%s", path)
+			t.Errorf("Failed to translate from Kube To Koki types. Resource Path=%s\n%s", path, convertedKokiObjString)
 			return nil
 		}
 		return nil


### PR DESCRIPTION
order of iteration for maps is inconsistent, so converting matchlabels to affinity selector-expressions wasn't consistent.

only sorting selector-expressions from matchlabels so other expressions' ordering is unaffected

@wlan0