### PR TITLE
add docs for volume sources in pods

### DIFF
--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)/..
+
+mkdocs build --clean
+
+aws s3 sync site/ s3://docs.koki.io/short/ --delete --acl public-read

--- a/testdata/pods/pod_spec_with_volume_source_aws_ebs.short.yaml
+++ b/testdata/pods/pod_spec_with_volume_source_aws_ebs.short.yaml
@@ -13,3 +13,4 @@ pod:
       ro: true
       vol_id: i4054053
       vol_type: aws_ebs
+      partition: 2

--- a/testdata/pods/pod_spec_with_volume_source_aws_ebs.yaml
+++ b/testdata/pods/pod_spec_with_volume_source_aws_ebs.yaml
@@ -14,6 +14,6 @@ spec:
     awsElasticBlockStore:
       volumeID: i4054053
       fsType: xfs
-      partition: 0
+      partition: 2
       readOnly: true
                 

--- a/testdata/pods/pod_spec_with_volume_source_azure_disk.yaml
+++ b/testdata/pods/pod_spec_with_volume_source_azure_disk.yaml
@@ -14,10 +14,7 @@ spec:
     azureDisk:
       diskName: azure_disk_name
       diskURI: disk://uri.azure.disk
-      cachingMode: ReadWrite
+      cachingMode: ReadWrite 
       fsType: xfs
       readOnly: false
       kind: Dedicated
-
-   
-                

--- a/testdata/pods/pod_spec_with_volume_source_azure_file.yaml
+++ b/testdata/pods/pod_spec_with_volume_source_azure_file.yaml
@@ -15,4 +15,3 @@ spec:
       secretName: azure_file_secret_name
       shareName: azure_file_share_name
       readOnly: true
-                

--- a/testdata/pods/pod_spec_with_volume_source_ceph_fs.yaml
+++ b/testdata/pods/pod_spec_with_volume_source_ceph_fs.yaml
@@ -19,4 +19,3 @@ spec:
       user: username
       secretFile: /path/to/secret
       readOnly: true
-                

--- a/testdata/pods/pod_spec_with_volume_source_host_path.yaml
+++ b/testdata/pods/pod_spec_with_volume_source_host_path.yaml
@@ -13,4 +13,4 @@ spec:
   - name: test_volume
     hostPath:
       path: /path/to/dir
-      type: BlockDevice      
+      type: BlockDevice 


### PR DESCRIPTION
@ublubu 

Added docs for all volume sources except `LocalVolumeSource` which seems to have been added after we implemented this (so in the last 2 weeks?) 