### PR TITLE
clusterrolebinding impl

### DIFF
--- a/converter/converters/koki_clusterrolebinding_to_kube.go
+++ b/converter/converters/koki_clusterrolebinding_to_kube.go
@@ -1,0 +1,51 @@
+package converters
+
+import (
+	rbac "k8s.io/api/rbac/v1"
+
+	"github.com/koki/short/types"
+)
+
+func Convert_Koki_ClusterRoleBinding_to_Kube(wrapper *types.ClusterRoleBindingWrapper) (*rbac.ClusterRoleBinding, error) {
+	kube := &rbac.ClusterRoleBinding{}
+	koki := wrapper.ClusterRoleBinding
+
+	kube.Name = koki.Name
+	kube.Namespace = koki.Namespace
+	if len(koki.Version) == 0 {
+		kube.APIVersion = "rbac.authorization.k8s.io/v1"
+	} else {
+		kube.APIVersion = koki.Version
+	}
+	kube.Kind = "ClusterRoleBinding"
+	kube.ClusterName = koki.Cluster
+	kube.Labels = koki.Labels
+	kube.Annotations = koki.Annotations
+
+	kube.Subjects = revertSubjects(koki.Subjects)
+	kube.RoleRef = revertRoleRef(koki.RoleRef)
+
+	return kube, nil
+}
+
+func revertSubjects(kokiSubjects []types.Subject) []rbac.Subject {
+	kubeSubjects := make([]rbac.Subject, len(kokiSubjects))
+	for i, kokiSubject := range kokiSubjects {
+		kubeSubjects[i] = rbac.Subject{
+			Kind:      kokiSubject.Kind,
+			APIGroup:  kokiSubject.APIGroup,
+			Name:      string(kokiSubject.Name),
+			Namespace: kokiSubject.Namespace,
+		}
+	}
+
+	return kubeSubjects
+}
+
+func revertRoleRef(kokiRef types.RoleRef) rbac.RoleRef {
+	return rbac.RoleRef{
+		APIGroup: kokiRef.APIGroup,
+		Kind:     kokiRef.Kind,
+		Name:     string(kokiRef.Name),
+	}
+}

--- a/converter/converters/kube_clusterrolebinding_to_koki.go
+++ b/converter/converters/kube_clusterrolebinding_to_koki.go
@@ -1,0 +1,47 @@
+package converters
+
+import (
+	rbac "k8s.io/api/rbac/v1"
+
+	"github.com/koki/short/types"
+)
+
+func Convert_Kube_ClusterRoleBinding_to_Koki(kube *rbac.ClusterRoleBinding) (*types.ClusterRoleBindingWrapper, error) {
+	koki := &types.ClusterRoleBinding{}
+
+	koki.Name = kube.Name
+	koki.Namespace = kube.Namespace
+	koki.Version = kube.APIVersion
+	koki.Cluster = kube.ClusterName
+	koki.Labels = kube.Labels
+	koki.Annotations = kube.Annotations
+
+	koki.Subjects = convertSubjects(kube.Subjects)
+	koki.RoleRef = convertRoleRef(kube.RoleRef)
+
+	return &types.ClusterRoleBindingWrapper{
+		ClusterRoleBinding: *koki,
+	}, nil
+}
+
+func convertSubjects(kubeSubjects []rbac.Subject) []types.Subject {
+	kokiSubjects := make([]types.Subject, len(kubeSubjects))
+	for i, kubeSubject := range kubeSubjects {
+		kokiSubjects[i] = types.Subject{
+			Kind:      kubeSubject.Kind,
+			APIGroup:  kubeSubject.APIGroup,
+			Name:      types.Name(kubeSubject.Name),
+			Namespace: kubeSubject.Namespace,
+		}
+	}
+
+	return kokiSubjects
+}
+
+func convertRoleRef(kubeRef rbac.RoleRef) types.RoleRef {
+	return types.RoleRef{
+		APIGroup: kubeRef.APIGroup,
+		Kind:     kubeRef.Kind,
+		Name:     types.Name(kubeRef.Name),
+	}
+}

--- a/converter/koki_converter.go
+++ b/converter/koki_converter.go
@@ -35,6 +35,8 @@ func DetectAndConvertFromKokiObj(kokiObj interface{}) (interface{}, error) {
 		return converters.Convert_Koki_Binding_to_Kube_Binding(kokiObj)
 	case *types.ClusterRoleWrapper:
 		return converters.Convert_Koki_ClusterRole_to_Kube(kokiObj)
+	case *types.ClusterRoleBindingWrapper:
+		return converters.Convert_Koki_ClusterRoleBinding_to_Kube(kokiObj)
 	case *types.ConfigMapWrapper:
 		return converters.Convert_Koki_ConfigMap_to_Kube_v1_ConfigMap(kokiObj)
 	case *types.ControllerRevisionWrapper:
@@ -104,6 +106,8 @@ func DetectAndConvertFromKubeObj(kubeObj runtime.Object) (interface{}, error) {
 		return converters.Convert_Kube_Binding_to_Koki_Binding(kubeObj)
 	case *rbac.ClusterRole:
 		return converters.Convert_Kube_ClusterRole_to_Koki(kubeObj)
+	case *rbac.ClusterRoleBinding:
+		return converters.Convert_Kube_ClusterRoleBinding_to_Koki(kubeObj)
 	case *v1.ConfigMap:
 		return converters.Convert_Kube_v1_ConfigMap_to_Koki_ConfigMap(kubeObj)
 	case *apps.ControllerRevision, *appsv1beta1.ControllerRevision, *appsv1beta2.ControllerRevision:

--- a/parser/native.go
+++ b/parser/native.go
@@ -46,6 +46,13 @@ func ParseKokiNativeObject(obj interface{}) (interface{}, error) {
 				return nil, serrors.InvalidValueForTypeContextError(err, objMap, result)
 			}
 			return result, nil
+		case "cluster_role_binding":
+			result := &types.ClusterRoleBindingWrapper{}
+			err := json.Unmarshal(bytes, result)
+			if err != nil {
+				return nil, serrors.InvalidValueForTypeContextError(err, objMap, result)
+			}
+			return result, nil
 		case "config_map":
 			configMap := &types.ConfigMapWrapper{}
 			err := json.Unmarshal(bytes, configMap)

--- a/testdata/cluster_role_bindings/crb.short.yaml
+++ b/testdata/cluster_role_bindings/crb.short.yaml
@@ -1,0 +1,43 @@
+cluster_role_binding:
+  name: fluentd-read
+  role: rbac.authorization.k8s.io.ClusterRole:fluentd-read
+  subjects:
+  - ServiceAccount:logging:fluentd
+  version: rbac.authorization.k8s.io/v1
+---
+cluster_role_binding:
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+  name: kops:dns-controller
+  role: rbac.authorization.k8s.io.ClusterRole:kops\:dns-controller
+  subjects:
+  - rbac.authorization.k8s.io.User:system\:serviceaccount\:kube-system\:dns-controller
+  version: rbac.authorization.k8s.io/v1
+---
+cluster_role_binding:
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+  name: kube-dns-autoscaler
+  role: rbac.authorization.k8s.io.ClusterRole:kube-dns-autoscaler
+  subjects:
+  - ServiceAccount:kube-system:kube-dns-autoscaler
+  version: rbac.authorization.k8s.io/v1
+---
+cluster_role_binding:
+  name: kubeadm:node-proxier
+  role: rbac.authorization.k8s.io.ClusterRole:system\:node-proxier
+  subjects:
+  - ServiceAccount:kube-system:kube-proxy
+  version: rbac.authorization.k8s.io/v1
+---
+cluster_role_binding:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    k8s-addon: rbac.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: kubelet-cluster-admin
+  role: rbac.authorization.k8s.io.ClusterRole:system\:node
+  subjects:
+  - rbac.authorization.k8s.io.User:kubelet
+  version: rbac.authorization.k8s.io/v1
+

--- a/testdata/cluster_role_bindings/crb.yaml
+++ b/testdata/cluster_role_bindings/crb.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluentd-read
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: dns-controller.addons.k8s.io
+  name: kops:dns-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kops:dns-controller
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:kube-system:dns-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-addon: kube-dns.addons.k8s.io
+  name: kube-dns-autoscaler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-dns-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: kube-dns-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeadm:node-proxier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-proxier
+subjects:
+- kind: ServiceAccount
+  name: kube-proxy
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+    k8s-addon: rbac.addons.k8s.io
+    kubernetes.io/cluster-service: "true"
+  name: kubelet-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kubelet

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -204,6 +204,13 @@ func TestClusterRole(t *testing.T) {
 	}
 }
 
+func TestClusterRoleBinding(t *testing.T) {
+	err := testResource("cluster_role_bindings", testFuncGenerator(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 type filePair struct {
 	kubeSpec   string
 	kokiSpec   string

--- a/types/clusterrole.go
+++ b/types/clusterrole.go
@@ -1,5 +1,13 @@
 package types
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/koki/json"
+	serrors "github.com/koki/structurederrors"
+)
+
 type ClusterRoleWrapper struct {
 	ClusterRole ClusterRole `json:"cluster_role"`
 }
@@ -27,4 +35,132 @@ type PolicyRule struct {
 	ResourceNames []string `json:"resource_names,omitempty"`
 
 	NonResourceURLs []string `json:"non_resource_urls,omitempty"`
+}
+
+type ClusterRoleBindingWrapper struct {
+	ClusterRoleBinding ClusterRoleBinding `json:"cluster_role_binding"`
+}
+
+// ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace,
+// and adds who information via Subject.
+type ClusterRoleBinding struct {
+	Version     string            `json:"version,omitempty"`
+	Cluster     string            `json:"cluster,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Subjects holds references to the objects the role applies to.
+	Subjects []Subject `json:"subjects"`
+
+	// RoleRef can only reference a ClusterRole in the global namespace.
+	// If the RoleRef cannot be resolved, the Authorizer must return an error.
+	RoleRef RoleRef `json:"role"`
+}
+
+type Subject struct {
+	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	Kind string `json:"kind"`
+	// APIGroup holds the API group of the referenced subject.
+	// Defaults to "" for ServiceAccount subjects.
+	// Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+	APIGroup string `json:"apiGroup,omitempty"`
+	Name     Name   `json:"name"`
+	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// the Authorizer should report an error.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// RoleRef contains information that points to the role being used
+type RoleRef struct {
+	APIGroup string `json:"apiGroup"`
+	Kind     string `json:"kind"`
+	Name     Name   `json:"name"`
+}
+
+func (r RoleRef) GroupKind() string {
+	if len(r.APIGroup) > 0 {
+		return fmt.Sprintf("%s.%s", r.APIGroup, r.Kind)
+	}
+
+	return r.Kind
+}
+
+func (r RoleRef) MarshalJSON() ([]byte, error) {
+	str := fmt.Sprintf("%s:%s", r.GroupKind(), EscapeName(r.Name))
+	return json.Marshal(str)
+}
+
+func (r *RoleRef) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+
+	segments := SplitAtUnescapedColons(str)
+	if len(segments) != 2 {
+		return serrors.InvalidValueForTypeErrorf(str, r, "expected 'group.kind:name'")
+	}
+
+	r.Name = UnescapeName(segments[1])
+
+	splitAt := strings.LastIndex(segments[0], ".")
+	if splitAt >= 0 {
+		r.APIGroup = segments[0][:splitAt]
+		r.Kind = segments[0][splitAt+1:]
+	} else {
+		return serrors.InvalidValueForTypeErrorf(str, r, "expected 'group.kind:name'")
+	}
+
+	return nil
+}
+
+func (r Subject) GroupKind() string {
+	if len(r.APIGroup) > 0 {
+		return fmt.Sprintf("%s.%s", r.APIGroup, r.Kind)
+	}
+
+	return r.Kind
+}
+
+func (r Subject) MarshalJSON() ([]byte, error) {
+	var str string
+	if len(r.Namespace) > 0 {
+		str = fmt.Sprintf("%s:%s:%s", r.GroupKind(), r.Namespace, EscapeName(r.Name))
+	} else {
+		str = fmt.Sprintf("%s:%s", r.GroupKind(), EscapeName(r.Name))
+	}
+	return json.Marshal(str)
+}
+
+func (r *Subject) UnmarshalJSON(data []byte) error {
+	var str string
+	err := json.Unmarshal(data, &str)
+	if err != nil {
+		return err
+	}
+
+	segments := SplitAtUnescapedColons(str)
+	if len(segments) != 3 && len(segments) != 2 {
+		return serrors.InvalidValueForTypeErrorf(str, r, "expected '[group.kind|kind]:name' OR '[group.kind|kind]:namespace:name'")
+	}
+
+	splitAt := strings.LastIndex(segments[0], ".")
+	if splitAt >= 0 {
+		r.APIGroup = segments[0][:splitAt]
+		r.Kind = segments[0][splitAt+1:]
+	} else {
+		r.Kind = segments[0]
+	}
+
+	if len(segments) == 2 {
+		r.Name = UnescapeName(segments[1])
+	} else { // len is 3
+		r.Namespace = segments[1]
+		r.Name = UnescapeName(segments[2])
+	}
+
+	return nil
 }

--- a/types/clusterrole_test.go
+++ b/types/clusterrole_test.go
@@ -1,0 +1,120 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/koki/json"
+)
+
+func TestRoleRef(t *testing.T) {
+	testOneRoleRef("group.group1.kind:name", RoleRef{
+		APIGroup: "group.group1",
+		Kind:     "kind",
+		Name:     "name",
+	}, t, false)
+	testOneRoleRef("kind:name", RoleRef{}, t, true)
+	testOneRoleRef("name", RoleRef{}, t, true)
+	testOneRoleRef("group.group1.kind", RoleRef{}, t, true)
+	testOneRoleRef("group.:name", RoleRef{
+		APIGroup: "group",
+		Kind:     "",
+		Name:     "name",
+	}, t, false)
+	// double backslash because it's a JSON string
+	testOneRoleRef(`rbac.authorization.k8s.io.ClusterRole:kops\\:dns-controller`, RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "kops:dns-controller",
+	}, t, false)
+}
+
+func testOneRoleRef(nakedStr string, obj RoleRef, t *testing.T, decodeError bool) {
+	str := `"` + nakedStr + `"`
+	t.Log(str, obj)
+	newObj := RoleRef{}
+	err := json.Unmarshal([]byte(str), &newObj)
+	if err != nil {
+		if decodeError {
+			return
+		}
+
+		t.Fatal(err)
+	} else if decodeError {
+		t.Fatal("expected a decode error")
+	}
+
+	b, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(string(b), str, newObj, obj)
+	if !reflect.DeepEqual(obj, newObj) {
+		t.Fatal("objects don't match")
+	}
+
+	if str != string(b) {
+		t.Fatal("strings don't match")
+	}
+}
+
+func TestSubject(t *testing.T) {
+	testOneSubject("group.group1.kind:name", Subject{
+		APIGroup: "group.group1",
+		Kind:     "kind",
+		Name:     "name",
+	}, t, false)
+	testOneSubject("group.group1.kind:namespace:name", Subject{
+		APIGroup:  "group.group1",
+		Kind:      "kind",
+		Namespace: "namespace",
+		Name:      "name",
+	}, t, false)
+	testOneSubject("kind:name", Subject{
+		Kind: "kind",
+		Name: "name",
+	}, t, false)
+	testOneSubject("kind:namespace:name", Subject{
+		Kind:      "kind",
+		Namespace: "namespace",
+		Name:      "name",
+	}, t, false)
+	testOneSubject("name", Subject{}, t, true)
+	testOneSubject("group.group1.kind", Subject{}, t, true)
+	testOneSubject("group.:name", Subject{
+		APIGroup: "group",
+		Kind:     "",
+		Name:     "name",
+	}, t, false)
+}
+
+func testOneSubject(nakedStr string, obj Subject, t *testing.T, decodeError bool) {
+	str := `"` + nakedStr + `"`
+	t.Log(str, obj)
+	newObj := Subject{}
+	err := json.Unmarshal([]byte(str), &newObj)
+	if err != nil {
+		if decodeError {
+			return
+		}
+
+		t.Fatal(err)
+	} else if decodeError {
+		t.Fatal("expected a decode error")
+	}
+
+	b, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(string(b), str, newObj, obj)
+	if !reflect.DeepEqual(obj, newObj) {
+		t.Fatal("objects don't match")
+	}
+
+	if str != string(b) {
+		t.Fatal("strings don't match")
+	}
+}

--- a/types/name.go
+++ b/types/name.go
@@ -1,0 +1,70 @@
+package types
+
+// Name indicates a string that may contain colons.
+// Escape its colons before joining with other strings (using colon as a separator).
+type Name string
+
+func TranslateEscapedRune(r rune) rune {
+	return r
+}
+
+func EscapeName(name Name) string {
+	// Replace : with \: and \ with \\
+	newRunes := []rune{}
+	for _, rune := range name {
+		switch rune {
+		case '\\', ':':
+			newRunes = append(newRunes, '\\', rune)
+		default:
+			newRunes = append(newRunes, rune)
+		}
+	}
+
+	return string(newRunes)
+}
+
+func UnescapeName(name string) Name {
+	// Replace \\ with \ and \: with :, but not if the \: was already touched
+	newRunes := []rune{}
+	isEscaped := false
+	for _, rune := range name {
+		if isEscaped {
+			newRunes = append(newRunes, TranslateEscapedRune(rune))
+			isEscaped = false
+		} else {
+			if rune == '\\' {
+				isEscaped = true
+			} else {
+				newRunes = append(newRunes, rune)
+			}
+		}
+	}
+
+	return Name(newRunes)
+}
+
+func SplitAtUnescapedColons(s string) []string {
+	segments := []string{}
+
+	segmentStart := 0
+	isEscaped := false
+	for i, rune := range s {
+		if isEscaped {
+			isEscaped = false
+		} else {
+			switch rune {
+			case '\\':
+				isEscaped = true
+			case ':':
+				segments = append(segments, s[segmentStart:i])
+				segmentStart = i + 1
+			}
+		}
+	}
+
+	if segmentStart <= len(s) {
+		segments = append(segments, s[segmentStart:len(s)])
+	}
+
+	return segments
+}

--- a/types/name_test.go
+++ b/types/name_test.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNameEscaping(t *testing.T) {
+	testOneName("", "", t)
+	testOneName(`\`, `\\`, t)
+	testOneName(`:`, `\:`, t)
+	testOneName(`\:`, `\\\:`, t)
+	testOneName(`:\`, `\:\\`, t)
+	testOneName(`system:serviceaccount:kube-system:dns-controller`,
+		`system\:serviceaccount\:kube-system\:dns-controller`, t)
+	testOneName(`bob`, `bob`, t)
+	testOneName(`bob\`, `bob\\`, t)
+}
+
+func testOneName(unescaped Name, escaped string, t *testing.T) {
+	actualEscaped := EscapeName(unescaped)
+	actualUnescaped := UnescapeName(escaped)
+	if actualEscaped != escaped || actualUnescaped != unescaped {
+		t.Fatalf("actual:\n  %s\n  %s\nexpected:\n  %s\n  %s\n", actualEscaped, actualUnescaped, escaped, unescaped)
+	}
+}
+
+func TestSplitAtUnescapedColons(t *testing.T) {
+	testOneSplit("", t, "")
+	testOneSplit(":", t, "", "")
+	testOneSplit(`\:`, t, `\:`)
+	testOneSplit(`\\:`, t, `\\`, "")
+	testOneSplit(`a:b:kops\:dns-controller`, t, `a`, `b`, `kops\:dns-controller`)
+	testOneSplit(`a:b:c`, t, `a`, `b`, `c`)
+}
+
+func testOneSplit(s string, t *testing.T, segments ...string) {
+	actualSegments := SplitAtUnescapedColons(s)
+	if !reflect.DeepEqual(actualSegments, segments) {
+		t.Fatalf("actual:\n  %#v\nexpected:\n  %#v", actualSegments, segments)
+	}
+}


### PR DESCRIPTION
Since ClusterRole names (and some other names) contain colons, I've created a new type `Name` to keep track of string fields that can contain colons.

When we combine them in composite fields `x:y:z`, we need to escape the colons first.

Related: #192 

@wlan0 